### PR TITLE
Updated Package/Type Refs to Fix Build

### DIFF
--- a/drivers/os/linux/os.go
+++ b/drivers/os/linux/os.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 
 	"github.com/docker/docker/pkg/mount"
-	"github.com/docker/libcontainer/label"
+	"github.com/opencontainers/runc/libcontainer/label"
 	osdriver "github.com/emccode/rexray/drivers/os"
 )
 
@@ -39,7 +39,7 @@ func Init() (osdriver.Driver, error) {
 
 }
 
-func (driver *Driver) GetMounts(deviceName, mountPoint string) ([]*mount.MountInfo, error) {
+func (driver *Driver) GetMounts(deviceName, mountPoint string) ([]*mount.Info, error) {
 
 	mounts, err := mount.GetMounts()
 	if err != nil {
@@ -52,7 +52,7 @@ func (driver *Driver) GetMounts(deviceName, mountPoint string) ([]*mount.MountIn
 		return nil, errors.New("Cannot specify mountPoint and deviceName")
 	}
 
-	var matchedMounts []*mount.MountInfo
+	var matchedMounts []*mount.Info
 	for _, mount := range mounts {
 		if mount.Mountpoint == mountPoint || mount.Source == deviceName {
 			matchedMounts = append(matchedMounts, mount)

--- a/drivers/os/osdriver.go
+++ b/drivers/os/osdriver.go
@@ -24,7 +24,7 @@ var Adapters map[string]Driver
 
 type Driver interface {
 	// Shows the existing mount points
-	GetMounts(string, string) ([]*mount.MountInfo, error)
+	GetMounts(string, string) ([]*mount.Info, error)
 
 	// Check whether path is mounted or not
 	Mounted(string) (bool, error)

--- a/os/os.go
+++ b/os/os.go
@@ -34,7 +34,7 @@ func initOSDrivers() {
 	}
 }
 
-func GetMounts(deviceName, mountPoint string) ([]*mount.MountInfo, error) {
+func GetMounts(deviceName, mountPoint string) ([]*mount.Info, error) {
 
 	for _, driver := range osdriver.Adapters {
 		mounts, err := driver.GetMounts(deviceName, mountPoint)


### PR DESCRIPTION
This patch provides two updates in order to enable REX-Ray to build
properly using the latest Docker sources.

- On 2015/03/28 commit 9a98556c2bc355170893568ca20e102cbda7d600 was
  pushed to the Docker repo and updated the struct in the file
  docker/pkg/mount/mountinfo.go to be mount.Info instead of
  mount.MountInfo. This patch updates all references to the type
  mount.MountInfo to mount.Info.

- On 2015/06/23 the Docker project libcontainer was moved to
  opencontainers/runc. This patch updates all references to the package
  "github.com/docker/libcontainer/label" to
  "github.com/opencontainers/runc/libcontainer/label".