### PR TITLE
Added Ability to Get Driver Names

### DIFF
--- a/drivers/storage/storagedriver.go
+++ b/drivers/storage/storagedriver.go
@@ -121,6 +121,14 @@ func init() {
 	debug = strings.ToUpper(os.Getenv("REXRAY_DEBUG"))
 }
 
+func GetDriverNames() ([]string) {
+    names := make([]string, 0, len(drivers))
+    for n := range drivers {
+       names = append(names, n)
+    }
+    return names
+}
+
 func GetDrivers(storageDrivers string) (map[string]Driver, error) {
 	var err error
 	var storageDriversArr []string

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -253,3 +253,8 @@ func CopySnapshot(runAsync bool, volumeID, snapshotID, snapshotName, targetSnaps
 	}
 	return &storagedriver.Snapshot{}, nil
 }
+
+
+func GetDriverNames() ([]string) {
+    return storagedriver.GetDriverNames()
+}


### PR DESCRIPTION
This patch provides the functionality for external clients to get a list of the registered driver names. This will serve the REX-ray CLI's new Get-Drivers verb. Getting a list of the registered, valid driver names is useful for debugging and diagnostics purposes.