### PR TITLE
Makefile Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.build/
 example
 release/*
 golang-crosscompile/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+.PHONY: all test clean deps build install
+
+ROOT_DIR := $(shell pwd)
+ifeq ($(origin GOPATH), undefined)
+	export GOPATH := $(ROOT_DIR)/.build
+endif
+export GOBIN := $(GOPATH)/bin
+GOFLAGS := $(GOFLAGS) -gcflags "-N -l"
+EMCCODE := $(GOPATH)/src/github.com/emccode
+GOAMZ_WRKDIR := $(GOPATH)/src/github.com/goamz/goamz
+GOAMZ_GITDIR := $(GOAMZ_WRKDIR)/.git
+GOAMZ_SNAP = https://github.com/clintonskitson/goamz.git
+GOAMZ_SNAP_BRANCH = snapcopy
+GOAMZ_GIT = git --git-dir=$(GOAMZ_GITDIR) --work-tree=$(GOAMZ_WRKDIR)
+GOAMZ_BRANCH = $(shell $(GOAMZ_GIT) branch --list | grep '^*' | tr -d '* ')
+GOAMZ_SNAPCOPY_REMOTE = $(GOAMZ_GIT) remote -v | grep snapcopy &> /dev/null
+GOAMZ_SNAPCOPY_REMOTE_ADD = $(GOAMZ_GIT) remote add -f snapcopy $(GOAMZ_SNAP) &> /dev/null
+GOAMZ_SNAPCOPY_CHECKOUT = $(GOAMZ_GIT) checkout -f snapcopy &> /dev/null
+
+all: install
+
+deps_rexray_sources:
+	@mkdir -p $(EMCCODE)
+	@if [ ! -e "$(EMCCODE)/rexray" ]; then \
+		ln -s $(ROOT_DIR) $(EMCCODE)/rexray &> /dev/null; \
+	fi
+	
+deps_go_get:
+	@go get -d $(GOFLAGS) ./...
+
+deps_goamz:
+	@$(GOAMZ_SNAPCOPY_REMOTE) || $(GOAMZ_SNAPCOPY_REMOTE_ADD)
+	@if [ "$(GOAMZ_BRANCH)" != "snapcopy" ]; then \
+		$(GOAMZ_SNAPCOPY_CHECKOUT); \
+	fi
+
+deps: deps_rexray_sources deps_go_get deps_goamz
+
+build: deps
+	@go build $(GOFLAGS) ./...
+
+install: deps
+	@cd $(EMCCODE)/rexray; \
+		go install $(GOFLAGS) ./...; \
+		cd $(ROOT_DIR)
+
+test: install
+	@go test $(GOFLAGS) ./...
+
+bench: install
+	@go test -run=NONE -bench=. $(GOFLAGS) ./...
+
+clean:
+	@go clean $(GOFLAGS) -i ./...


### PR DESCRIPTION
This patch adds support for a Makefile that makes building REX-Ray on a
clean system incredibly simple. Just type "make" and at the end of the
build a shiny new binary named "rexray" will be in $GOPATH/bin.

The best part is that if you unset the GOPATH variable in your shell,
the makefile will create a new, clean, isolated build environment for
you in the .build directory relative to the current directory. This
means all you  have to do to get a fresh build each time is remove the
.build  directory, and you can test building REX-Ray from scratch, in
isolation from any other Go environment on your system.