### PR TITLE
RPM Support in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .build/
+.rpmbuild/
 example
 release/*
 golang-crosscompile/

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,14 @@ ifeq ($(origin GOPATH), undefined)
 endif
 export GOBIN := $(GOPATH)/bin
 GOFLAGS := $(GOFLAGS) -gcflags "-N -l"
+RPMBUILD := $(ROOT_DIR)/.rpmbuild
 EMCCODE := $(GOPATH)/src/github.com/emccode
 GOAMZ_WRKDIR := $(GOPATH)/src/github.com/goamz/goamz
 GOAMZ_GITDIR := $(GOAMZ_WRKDIR)/.git
 GOAMZ_SNAP = https://github.com/clintonskitson/goamz.git
 GOAMZ_SNAP_BRANCH = snapcopy
 GOAMZ_GIT = git --git-dir=$(GOAMZ_GITDIR) --work-tree=$(GOAMZ_WRKDIR)
-GOAMZ_BRANCH = $(shell $(GOAMZ_GIT) branch --list | grep '^*' | tr -d '* ')
+GOAMZ_BRANCH = $(shell $(GOAMZ_GIT) branch --list | grep '^*' | awk '{print $$2}')
 GOAMZ_SNAPCOPY_REMOTE = $(GOAMZ_GIT) remote -v | grep snapcopy &> /dev/null
 GOAMZ_SNAPCOPY_REMOTE_ADD = $(GOAMZ_GIT) remote add -f snapcopy $(GOAMZ_SNAP) &> /dev/null
 GOAMZ_SNAPCOPY_CHECKOUT = $(GOAMZ_GIT) checkout -f snapcopy &> /dev/null
@@ -26,7 +27,9 @@ deps_rexray_sources:
 	fi
 	
 deps_go_get:
-	@go get -d $(GOFLAGS) ./...
+	@cd $(EMCCODE)/rexray; \
+		go get -d $(GOFLAGS) ./...; \
+		cd $(ROOT_DIR)
 
 deps_goamz:
 	@$(GOAMZ_SNAPCOPY_REMOTE) || $(GOAMZ_SNAPCOPY_REMOTE_ADD)
@@ -36,8 +39,24 @@ deps_goamz:
 
 deps: deps_rexray_sources deps_go_get deps_goamz
 
+rpm: install
+	@rm -fr $(RPMBUILD)
+	
+	@mkdir -p $(RPMBUILD)/{RPMS,SRPMS,SPECS,tmp}
+	@ln -s $(ROOT_DIR) $(RPMBUILD)/BUILD
+	@ln -s $(ROOT_DIR) $(RPMBUILD)/SOURCES
+	@sed -e 's|$${RPMBUILD}|$(RPMBUILD)|g' \
+		-e 's|$${GOPATH}|$(GOPATH)|g' \
+		$(ROOT_DIR)/rexray.spec > $(RPMBUILD)/SPECS/rexray.spec
+
+	@cd $(RPMBUILD); \
+		rpmbuild -ba SPECS/rexray.spec; \
+		cd $(ROOT_DIR)
+
 build: deps
-	@go build $(GOFLAGS) ./...
+	@cd $(EMCCODE)/rexray; \
+		go build $(GOFLAGS) ./...; \
+		cd $(ROOT_DIR)
 
 install: deps
 	@cd $(EMCCODE)/rexray; \
@@ -45,10 +64,16 @@ install: deps
 		cd $(ROOT_DIR)
 
 test: install
-	@go test $(GOFLAGS) ./...
+	@cd $(EMCCODE)/rexray; \
+		go test $(GOFLAGS) ./...; \
+		cd $(ROOT_DIR)
 
 bench: install
-	@go test -run=NONE -bench=. $(GOFLAGS) ./...
+	@cd $(EMCCODE)/rexray; \
+		go test -run=NONE -bench=. $(GOFLAGS) ./...; \
+		cd $(ROOT_DIR)
 
 clean:
-	@go clean $(GOFLAGS) -i ./...
+	@cd $(EMCCODE)/rexray; \
+		go clean $(GOFLAGS) -i ./...; \
+		cd $(ROOT_DIR)

--- a/rexray.spec
+++ b/rexray.spec
@@ -1,0 +1,35 @@
+%define        _topdir  ${RPMBUILD}
+%define        _tmppath %{_topdir}/tmp
+
+Summary: Tool for managing remote & local storage.
+Name: rexray
+Version: 1.0
+Release: 1
+License: Apache License
+Group: Applications/Storage
+#Source: https://github.com/emccode/rexray/archive/master.zip
+URL: https://github.com/emccode/rexray
+Vendor: EMC{code}
+Packager: Andrew Kutz <sakutz@gmail.com>
+BuildArch: x86_64
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}
+
+%description
+A guest based storage introspection tool that 
+allows local visibility and management from cloud 
+and storage platforms.
+
+%prep
+
+%build
+
+%install
+mkdir -p $RPM_BUILD_ROOT/usr/bin
+cp -a ${GOPATH}/bin/rexray $RPM_BUILD_ROOT/usr/bin
+
+%clean
+rm -rf "$RPM_BUILD_ROOT"
+
+%files
+%defattr(-,root,root,-)
+%{_bindir}/*


### PR DESCRIPTION
This patch adds support for the Makefile so that "make rpm" will build
REX-Ray from source using the working tree and produce and RPM from the
compiled binary.