### PR TITLE
added volume options on creation for docker daemon

### DIFF
--- a/daemon/module/docker/remotevolumedriver/remvoldriver.go
+++ b/daemon/module/docker/remotevolumedriver/remvoldriver.go
@@ -112,8 +112,9 @@ var (
 )
 
 type pluginRequest struct {
-	Name       string `json:"Name,ommitempty"`
-	InstanceID string `json:"Instanceid,ommitempty"`
+	Name       string            `json:"Name,omitempty"`
+	Opts       volume.VolumeOpts `json:"Opts,omitempty"`
+	InstanceID string            `json:"Instanceid,omitempty"`
 }
 
 func (mod *Module) Start() error {
@@ -225,8 +226,7 @@ func (mod *Module) buildMux() *http.ServeMux {
 			http.Error(w, fmt.Sprintf("{\"Error\":\"%s\"}", err.Error()), 500)
 			return
 		}
-
-		err := mod.vdm.Create(pr.Name)
+		err := mod.vdm.Create(pr.Name, pr.Opts)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("{\"Error\":\"%s\"}", err.Error()), 500)
 			return

--- a/daemon/module/docker/volumedriver/voldriver.go
+++ b/daemon/module/docker/volumedriver/voldriver.go
@@ -101,7 +101,8 @@ var (
 )
 
 type pluginRequest struct {
-	Name string `json:"Name,ommitempty"`
+	Name string            `json:"Name,omitempty"`
+	Opts volume.VolumeOpts `json:"Opts,omitempty"`
 }
 
 func (mod *Module) Start() error {
@@ -214,7 +215,7 @@ func (mod *Module) buildMux() *http.ServeMux {
 			return
 		}
 
-		err := mod.vdm.Create(pr.Name)
+		err := mod.vdm.Create(pr.Name, pr.Opts)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("{\"Error\":\"%s\"}", err.Error()), 500)
 			return

--- a/volume/driver.go
+++ b/volume/driver.go
@@ -1,5 +1,7 @@
 package volume
 
+type VolumeOpts map[string]string
+
 type Driver interface {
 	// Mount will return a mount point path when specifying either a volumeName or volumeID.  If a overwriteFs boolean
 	// is specified it will overwrite the FS based on newFsType if it is detected that there is no FS present.
@@ -11,8 +13,8 @@ type Driver interface {
 	// Path will return the mounted path of the volumeName or volumeID.
 	Path(volumeName, volumeID string) (string, error)
 
-	// Create will create a new volume with the volumeName.
-	Create(volumeName string) error
+	// Create will create a new volume with the volumeName and opts.
+	Create(volumeName string, opts VolumeOpts) error
 
 	// Remove will remove a volume of volumeName.
 	Remove(volumeName string) error

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -106,9 +106,9 @@ func (vdm *VolumeDriverManager) Path(volumeName, volumeID string) (string, error
 	return "", errors.New("no volume manager specified")
 }
 
-func (vdm *VolumeDriverManager) Create(volumeName string) error {
+func (vdm *VolumeDriverManager) Create(volumeName string, volumeOpts VolumeOpts) error {
 	for _, driver := range vdm.Drivers {
-		return driver.Create(volumeName)
+		return driver.Create(volumeName, volumeOpts)
 	}
 	return errors.New("no volume manager specified")
 }


### PR DESCRIPTION
This PR accommodates upcoming changes in the Docker Volume API.  The change is that a map[string]string is now passed for creation options.

This enables commands like the following directly from Docker.
docker volume create --driver=rexray --opt=size=16 --opt=IOPS=100 --opt=volumetype=ssd

https://github.com/docker/docker/pull/14242/files