### PR TITLE
updated local volume driver socket location

### DIFF
--- a/daemon/module/docker/volumedriver/voldriver.go
+++ b/daemon/module/docker/volumedriver/voldriver.go
@@ -21,7 +21,7 @@ import (
 	"github.com/emccode/rexray/volume"
 )
 
-const MOD_ADDR = "unix:///run/docker/plugins/rexray-local.sock"
+const MOD_ADDR = "unix:///run/docker/plugins/rexray.sock"
 const MOD_PORT = 7980
 const MOD_NAME = "DockerVolumeDriverModule"
 const MOD_DESC = "The REX-Ray Docker VolumeDriver module"


### PR DESCRIPTION
The updates the local volume driver to have a socket location of `/run/docker/plugins/rexray.sock` instead of `rexray-local.sock`.  This should keep some level of backward compatibility with existing functionality.
