### PR TITLE
[32] Add commit hash to 'rexray version'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,12 @@ WD := $(shell pwd)
 export MAKEFLAGS := $(MAKEFLAGS) -k
 export GOBIN := $(GOPATH)/bin
 export GO15VENDOREXPERIMENT := 1
-SEMVER := $(shell git describe --tags | sed -E 's/^v\.?//g')
+GITDSC := $(shell git describe --long)
+BRANCH := $(shell git branch | grep '*' | awk '{print $$2}')
+TGTVER := $(shell cat VERSION | tr -d " \n\r\t")
+BLDDTE := $(shell date +%s)
+CMTDTE := $(shell git show HEAD -s --format=%ct)
+CMTHSH := $(shell git show HEAD -s --format=%H)
 GOFLAGS := $(GOFLAGS)
 GLIDE := $(GOBIN)/glide
 NV := $$($(GLIDE) novendor)
@@ -14,8 +19,14 @@ BASEDIR := $(GOPATH)/src/$(BASEPKG)
 BASEDIR_NAME := $(shell basename $(BASEDIR))
 BASEDIR_PARENTDIR := $(shell dirname $(BASEDIR))
 BASEDIR_TEMPMVLOC := $(BASEDIR_PARENTDIR)/.$(BASEDIR_NAME)-$(shell date +%s)
-VERSIONPKG := $(BASEPKG)
-LDFLAGS := -ldflags "-X $(VERSIONPKG).Version=$(SEMVER)" 
+VERSIONPKG := $(BASEPKG)/version_info
+LDF_GITDSC := -X $(VERSIONPKG).GitDescribe=$(GITDSC)
+LDF_BRANCH := -X $(VERSIONPKG).BranchName=$(BRANCH)
+LDF_TGTVER := -X $(VERSIONPKG).TargetVersion=$(TGTVER)
+LDF_BLDDTE := -X $(VERSIONPKG).BuildDateEpochStr=$(BLDDTE)
+LDF_CMTDTE := -X $(VERSIONPKG).CommitDateEpochStr=$(CMTDTE)
+LDF_CMTHSH := -X $(VERSIONPKG).CommitHash=$(CMTHSH)
+LDFLAGS := -ldflags "$(LDF_GITDSC) $(LDF_BRANCH) $(LDF_TGTVER) $(LDF_BLDDTE) $(LDF_CMTDTE) $(LDF_CMTHSH)" 
 RPMBUILD := $(WD)/.rpmbuild
 EMCCODE := $(GOPATH)/src/github.com/emccode
 PRINT_STATUS = export EC=$$?; cd $(WD); if [ "$$EC" -eq "0" ]; then printf "SUCCESS!\n"; else exit $$EC; fi

--- a/rexray.go
+++ b/rexray.go
@@ -2,8 +2,6 @@ package rexray
 
 import _ "github.com/emccode/rexray/imports"
 
-var Version string
-
 func init() {
 
 }

--- a/rexray/commands/commands.go
+++ b/rexray/commands/commands.go
@@ -5,11 +5,12 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/emccode/rexray"
 	"github.com/emccode/rexray/util"
+	version "github.com/emccode/rexray/version_info"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v1"
 )
@@ -96,7 +97,13 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("%v\n", rexray.Version)
+
+		buildDate := time.Unix(version.BuildDate(), 0)
+
+		fmt.Printf("SemVer: %s\n", version.FullSemVer())
+		fmt.Printf("Branch: %s\n", version.Branch())
+		fmt.Printf("Commit: %s\n", version.Sha())
+		fmt.Printf("Formed: %s\n", buildDate.Format(time.RFC1123))
 	},
 }
 

--- a/version_info/version_info.go
+++ b/version_info/version_info.go
@@ -1,0 +1,215 @@
+package version_info
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strconv"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+const SemVerPatt = `^[^\d]*(\d+)\.(\d+)\.(\d+)(?:-(.+?))?(?:-(\d+)-g(.+))?$`
+
+var (
+	GitDescribe        string
+	CommitHash         string
+	CommitDateEpochStr string
+	BuildDateEpochStr  string
+	BranchName         string
+	TargetVersion      string
+
+	version  *Version
+	semVerRx *regexp.Regexp
+)
+
+type Version struct {
+	SemVer          string `json:"semVer"`
+	FullSemVer      string `json:"fullSemVer"`
+	Major           int32  `json:"major"`
+	Minor           int32  `json:"minor"`
+	Patch           int32  `json:"patch"`
+	MajorMinorPatch string `json:"major.minor.patch"`
+	PreReleaseTag   string `json:"preReleaseTag"`
+	Build           int64  `json:"build"`
+	Sha             string `json:"sha"`
+	BranchName      string `json:"branchName"`
+	CommitDate      int64  `json:"commitDate"`
+	BuildDate       int64  `json:"buildDate"`
+}
+
+func init() {
+	var semVerRxErr error
+	semVerRx, semVerRxErr = regexp.Compile(SemVerPatt)
+	if semVerRxErr != nil {
+		panic(semVerRxErr)
+	}
+}
+
+func getVersion() *Version {
+	if version == nil {
+		versionFields := map[string]interface{}{
+			"gitDescribe":     GitDescribe,
+			"commitHash":      CommitHash,
+			"commitDateEpoch": CommitDateEpochStr,
+			"buildDateEpcoh":  BuildDateEpochStr,
+			"branchName":      BranchName,
+			"targetVersion":   TargetVersion,
+		}
+		log.WithFields(versionFields).Debug("rexray version info")
+		version = parseSemVer(GitDescribe, TargetVersion)
+	}
+
+	return version
+}
+
+func ParseSemVer(semVer string) *Version {
+	return parseSemVer(semVer, "")
+}
+
+func parseSemVer(semVer, targetVer string) *Version {
+
+	commitDate, commitDateErr := strconv.ParseInt(CommitDateEpochStr, 10, 64)
+	if commitDateErr != nil {
+		panic(commitDateErr)
+	}
+	buildDate, buildDateErr := strconv.ParseInt(BuildDateEpochStr, 10, 64)
+	if buildDateErr != nil {
+		panic(buildDateErr)
+	}
+
+	v := &Version{
+		Sha:        CommitHash,
+		BranchName: BranchName,
+		CommitDate: commitDate,
+		BuildDate:  buildDate,
+	}
+
+	parseSemVer_(v, semVer, targetVer)
+	log.WithField("version", v).Debug("parsed version")
+	return v
+}
+
+func parseSemVer_(v *Version, semVer, targetVer string) {
+
+	svm := semVerRx.FindStringSubmatch(semVer)
+	if svm == nil {
+		return
+	}
+
+	var tvm []string
+	if targetVer != "" {
+		tvm = semVerRx.FindStringSubmatch(targetVer)
+	}
+
+	if tvm == nil {
+		parseSemVerParts(v, svm)
+	} else {
+		parseSemVerParts(v, tvm)
+	}
+
+	v.MajorMinorPatch = fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+
+	var semVerBuff bytes.Buffer
+	semVerBuff.WriteString(v.MajorMinorPatch)
+
+	if v.PreReleaseTag != "" {
+		semVerBuff.WriteString("-")
+		semVerBuff.WriteString(v.PreReleaseTag)
+		v.SemVer = semVerBuff.String()
+	}
+
+	if len(svm) >= 6 && svm[5] != "" {
+		log.WithField("build", svm[5]).Debug("parsed build")
+		build, buildErr := strconv.ParseInt(svm[5], 10, 64)
+		if buildErr != nil {
+			panic(buildErr)
+		}
+		v.Build = build
+		semVerBuff.WriteString("+")
+		semVerBuff.WriteString(svm[5])
+	}
+	v.FullSemVer = semVerBuff.String()
+}
+
+func parseSemVerParts(v *Version, m []string) {
+	log.WithField("semVerParts", m).Debug("parsing matched semver parts")
+
+	major, majorErr := strconv.ParseInt(m[1], 10, 32)
+	if majorErr != nil {
+		panic(majorErr)
+	}
+	minor, minorErr := strconv.ParseInt(m[2], 10, 32)
+	if minorErr != nil {
+		panic(minorErr)
+	}
+	patch, patchErr := strconv.ParseInt(m[3], 10, 32)
+	if patchErr != nil {
+		panic(patchErr)
+	}
+
+	var preReleaseTag string
+	if len(m) >= 5 && m[4] != "" {
+		preReleaseTag = m[4]
+	}
+
+	/*log.WithFields(log.Fields{
+		"major":         major,
+		"minor":         minor,
+		"patch":         patch,
+		"preReleaseTag": preReleaseTag,
+	}).Debug("parsed major, minor, patch, & pre-release tag")*/
+
+	v.Major = int32(major)
+	v.Minor = int32(minor)
+	v.Patch = int32(patch)
+	v.PreReleaseTag = preReleaseTag
+}
+
+func SemVer() string {
+	return getVersion().SemVer
+}
+
+func FullSemVer() string {
+	return getVersion().FullSemVer
+}
+
+func Major() int32 {
+	return getVersion().Major
+}
+
+func Minor() int32 {
+	return getVersion().Minor
+}
+
+func Patch() int32 {
+	return getVersion().Patch
+}
+
+func MajorMinorPatch() string {
+	return getVersion().MajorMinorPatch
+}
+
+func PreReleaseTag() string {
+	return getVersion().PreReleaseTag
+}
+
+func Build() int64 {
+	return getVersion().Build
+}
+
+func Sha() string {
+	return getVersion().Sha
+}
+
+func Branch() string {
+	return getVersion().BranchName
+}
+
+func CommitDate() int64 {
+	return getVersion().CommitDate
+}
+
+func BuildDate() int64 {
+	return getVersion().BuildDate
+}


### PR DESCRIPTION
This patch handles issue #32 and changes the output of the `rexray version` command to include additional information about the REX-ray version and sources used to build it. For example:

```
[0]akutz@poppy:rexray$ rexray version
SemVer: 0.2.0-rc2+2
Branch: feature/32-version-info
Commit: 86d6ced73b7968cdf292aac11ac6f46c86e01088
Formed: Thu, 10 Sep 2015 18:50:47 CDT
```

Additionally, if the `VERSION` file exists at the root of the repository and the file contains a valid semantic version, then that version's `major`.`minor`.`patch`-`preReleaseTag` components will be used in lieu of those grokked from a call to `git describe --long` at build time.