### PR TITLE
[40] Always load /etc/environment if present

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -99,6 +99,28 @@ func ReadPidFile() (int, error) {
 	return pid, nil
 }
 
+func LineReader(filePath string) <-chan string {
+	if !FileExists(filePath) {
+		return nil
+	}
+
+	c := make(chan string)
+	go func() {
+		f, err := os.Open(filePath)
+		if err != nil {
+			panic(err)
+		}
+		defer f.Close()
+
+		s := bufio.NewScanner(f)
+		for s.Scan() {
+			c <- s.Text()
+		}
+		close(c)
+	}()
+	return c
+}
+
 func FileExists(filePath string) bool {
 	if _, err := os.Stat(filePath); !os.IsNotExist(err) {
 		return true


### PR DESCRIPTION
Because sudo doesn't always play nice with /etc/environment and so many people place configuration information there even when inappropriate or not fully understood, REX-Ray should manually load /etc/environment in order to relieve users of possible issues due to Linux systems being so disparate and supporting so many different configuration options.

This patch solves the above issue. Although tangential, issues #38 and #39 are related.