### PR TITLE
[36] Broken Service

### DIFF
--- a/rexray/commands/commands.go
+++ b/rexray/commands/commands.go
@@ -45,12 +45,14 @@ func initCommands() {
 	adapterCmd.AddCommand(adapterGetInstancesCmd)
 
 	RexrayCmd.AddCommand(serviceStartCmd)
+	RexrayCmd.AddCommand(serviceRestartCmd)
 	RexrayCmd.AddCommand(serviceStopCmd)
 	RexrayCmd.AddCommand(serviceStatusCmd)
 
 	RexrayCmd.AddCommand(serviceCmd)
 	serviceCmd.AddCommand(serviceInstallCmd)
 	serviceCmd.AddCommand(serviceStartCmd)
+	serviceCmd.AddCommand(serviceRestartCmd)
 	serviceCmd.AddCommand(serviceStopCmd)
 	serviceCmd.AddCommand(serviceStatusCmd)
 	serviceCmd.AddCommand(serviceInitSysCmd)
@@ -310,6 +312,14 @@ var serviceStartCmd = &cobra.Command{
 	Short: "Start the service",
 	Run: func(cmd *cobra.Command, args []string) {
 		Start()
+	},
+}
+
+var serviceRestartCmd = &cobra.Command{
+	Use:   "restart",
+	Short: "Restart the service",
+	Run: func(cmd *cobra.Command, args []string) {
+		Restart()
 	},
 }
 

--- a/rexray/commands/rexraycli.go
+++ b/rexray/commands/rexraycli.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	_ "github.com/emccode/rexray/imports"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -14,8 +16,6 @@ import (
 	"github.com/emccode/rexray/volume"
 )
 
-const REXHOME = "/opt/rexray"
-const EXEFILE = "/opt/rexray/rexray"
 const ENVFILE = "/etc/rexray/rexray.env"
 const CFGFILE = "/etc/rexray/rexray.conf"
 const UNTFILE = "/etc/systemd/system/rexray.service"
@@ -246,7 +246,11 @@ func isInitDriverManagersCmd(cmd *cobra.Command) bool {
 		cmd != serviceInstallCmd &&
 		cmd != serviceStatusCmd &&
 		cmd != serviceStopCmd &&
-		!(cmd == serviceStartCmd && (isClient || isForeground))
+		!(cmd == serviceStartCmd && (isClient || isForeground)) &&
+		cmd != moduleCmd &&
+		cmd != moduleTypesCmd &&
+		cmd != moduleInstancesCmd &&
+		cmd != moduleInstancesListCmd
 }
 
 func initDriverManagers() error {


### PR DESCRIPTION
This patch fixes the issue #36 where changes to the infrastructure inadvertently broke the service initialization files installed by 'rexray service install'.

Additionally, thanks to a note by @drumulonimbus, this patch updates the 'rexray service install' command so that the binary is no longer installed in `/opt/rexray'. Instead it is up to the user to locate the binary in the desired location prior to invoking 'rexray service install', at which point the service will be installed, linking to the binary in its current location.