### PR TITLE
Master Branch Build Artifacts on Bintray

### DIFF
--- a/.bintray.json
+++ b/.bintray.json
@@ -1,0 +1,21 @@
+{
+    "package": {
+        "name": "rexray", 
+        "repo": "generic",
+        "subject": "akutz"
+    },
+
+    "version": {
+        "name": "${SEMVER}",
+        "desc": "${DSCRIP}",
+        "released": "${RELDTE}",
+        "gpgSign": false
+    },
+
+    "files": [{
+        "includePattern": ".bin/(.+)/(.*\.tar\.gz)",
+        "uploadPattern": "$2"
+    }],
+
+    "publish": true
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.bintray-filtered.json
+.bin/
 vendor/
 .build/
 .rpmbuild/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,13 @@
 language: go
 go:
-  - 1.5
+- 1.5.1
+script: make build-all
+deploy:
+  provider: bintray
+  file: .bintray-filtered.json
+  user: akutz
+  key: 60b9a06880345572303b65d079dd9f82d16fb8b6
+  skip_cleanup: true
+  on:
+    repo: emccode/rexray
+    branch: master

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# REX-Ray [![Build Status](https://travis-ci.org/emccode/rexray.svg?branch=master)](https://travis-ci.org/emccode/rexray)
+# REX-Ray [![Build Status](https://travis-ci.org/emccode/rexray.svg?branch=master)](https://travis-ci.org/emccode/rexray) [ ![Download](https://api.bintray.com/packages/akutz/generic/rexray/images/download.svg) ](https://bintray.com/akutz/generic/rexray/_latestVersion#files)
 ```REX-Ray``` provides visibility and management of external/underlying storage via guest storage introspection. Available as a Go package, CLI tool, and Linux service, and with built-in third-party support for tools such as ```Docker```, ```REX-Ray``` is easily integrated into any workflow. For example, here's how to list storage for a guest hosted on Amazon Web Services (AWS) with ```REX-Ray```:
 
 ```bash

--- a/rexray/commands/commands.go
+++ b/rexray/commands/commands.go
@@ -103,6 +103,7 @@ var versionCmd = &cobra.Command{
 		buildDate := time.Unix(version.BuildDate(), 0)
 
 		fmt.Printf("SemVer: %s\n", version.FullSemVer())
+		fmt.Printf("Binary: %s\n", version.BinArch())
 		fmt.Printf("Branch: %s\n", version.Branch())
 		fmt.Printf("Commit: %s\n", version.Sha())
 		fmt.Printf("Formed: %s\n", buildDate.Format(time.RFC1123))

--- a/version_info/version_info.go
+++ b/version_info/version_info.go
@@ -18,6 +18,7 @@ var (
 	BuildDateEpochStr  string
 	BranchName         string
 	TargetVersion      string
+	BinArchStr         string
 
 	version  *Version
 	semVerRx *regexp.Regexp
@@ -36,6 +37,7 @@ type Version struct {
 	BranchName      string `json:"branchName"`
 	CommitDate      int64  `json:"commitDate"`
 	BuildDate       int64  `json:"buildDate"`
+	BinArch         string `json:"binArch"`
 }
 
 func init() {
@@ -55,6 +57,7 @@ func getVersion() *Version {
 			"buildDateEpcoh":  BuildDateEpochStr,
 			"branchName":      BranchName,
 			"targetVersion":   TargetVersion,
+			"binArch":         BinArchStr,
 		}
 		log.WithFields(versionFields).Debug("rexray version info")
 		version = parseSemVer(GitDescribe, TargetVersion)
@@ -83,6 +86,7 @@ func parseSemVer(semVer, targetVer string) *Version {
 		BranchName: BranchName,
 		CommitDate: commitDate,
 		BuildDate:  buildDate,
+		BinArch:    BinArchStr,
 	}
 
 	parseSemVer_(v, semVer, targetVer)
@@ -212,4 +216,8 @@ func CommitDate() int64 {
 
 func BuildDate() int64 {
 	return getVersion().BuildDate
+}
+
+func BinArch() string {
+	return getVersion().BinArch
 }


### PR DESCRIPTION
This patch updates the Travis-CI build process so that artifacts generated by all commits to the master branch are uploaded to Bintray. A future patch will also the uploading of artifacts created from release tags to the related GitHub release.