### PR TITLE
SymLink Absolute Paths vs PATH

### DIFF
--- a/rexray/commands/service.go
+++ b/rexray/commands/service.go
@@ -380,6 +380,10 @@ func createUnitFile(exeFile string) {
 }
 
 func createInitFile(exeFile string) {
+	log.WithFields(log.Fields{
+		"exeFile":  exeFile,
+		"initFile": INTFILE,
+	}).Debug("creating symlink")
 	os.Symlink(exeFile, INTFILE)
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -134,7 +134,12 @@ func FileExistsInPath(fileName string) bool {
 }
 
 func GetPathParts(path string) (dirPath, fileName, absPath string) {
+	lookup, lookupErr := exec.LookPath(path)
+	if lookupErr == nil {
+		path = lookup
+	}
 	absPath, _ = filepath.Abs(path)
+
 	dirPath = filepath.Dir(absPath)
 	fileName = filepath.Base(absPath)
 	return


### PR DESCRIPTION
This patch corrects the bug where the command `rexray service install` would fail if the `rexray` binary was being accessed via the `$PATH` variable instead of an absolute or relative path.