### PR TITLE
Volume Mount Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ This utility is HTTP and Unix socket aware so can do POST messages in a HTTP fri
 < Content-Type: appplication/vnd.docker.plugins.v1+json
 < Date: Fri, 22 May 2015 15:52:21 GMT
 < Content-Length: 49
-{"Mountpoint": "/var/lib/docker/volumes/test22"}
+{"Mountpoint": "/var/lib/rexray/volumes/test22"}
 ```
 
 # Contributions

--- a/volume/docker/volume.go
+++ b/volume/docker/volume.go
@@ -13,10 +13,10 @@ import (
 	"github.com/emccode/rexray/volume"
 )
 
-const ProviderName = "docker"
-
 const (
-	defaultVolumeSize int64 = 16
+	ProviderName            = "docker"
+	MountDirectory          = "/var/lib/rexray/volumes"
+	DefaultVolumeSize int64 = 16
 )
 
 type Driver struct {
@@ -26,6 +26,7 @@ type Driver struct {
 
 func init() {
 	volume.Register(ProviderName, Init)
+	os.MkdirAll(MountDirectory, 0755)
 }
 
 func Init(
@@ -45,7 +46,7 @@ func getVolumeMountPath(name string) (string, error) {
 		return "", errors.New("Missing volume name")
 	}
 
-	return fmt.Sprintf("/var/lib/docker/volumes/%s", name), nil
+	return fmt.Sprintf("%s/%s", MountDirectory, name), nil
 }
 
 // Mount will perform the steps to get an existing Volume with or without a fileystem mounted to a guest
@@ -304,7 +305,7 @@ func (driver *Driver) Create(volumeName string, volumeOpts volume.VolumeOpts) er
 	}
 	size := int64(sizei)
 	if size == 0 {
-		size = defaultVolumeSize
+		size = DefaultVolumeSize
 	}
 
 	if availabilityZone, ok = volumeOpts["availabilityzone"]; !ok {


### PR DESCRIPTION
This patch changes the path to which volumes were mounted from `/var/lib/docker/volumes` to `/var/lib/rexray/volumes`. The README has been updated to reflect this change. 

This PR is related to Issue #27.