### PR TITLE
Updating Instructions on How to get REX-Ray

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# REX-Ray [![Build Status](https://travis-ci.org/emccode/rexray.svg?branch=master)](https://travis-ci.org/emccode/rexray) [ ![Download](https://api.bintray.com/packages/emccode/rexray/stable/images/download.svg) ](https://dl.bintray.com/emccode/rexray/stable/latest/)
+# REX-Ray [![Build Status](https://travis-ci.org/emccode/rexray.svg?branch=master)](https://travis-ci.org/emccode/rexray) [ ![Download](https://api.bintray.com/packages/emccode/rexray/staged/images/download.svg) ](https://dl.bintray.com/emccode/rexray/staged/latest/)
 ```REX-Ray``` provides visibility and management of external/underlying storage via guest storage introspection. Available as a Go package, CLI tool, and Linux service, and with built-in third-party support for tools such as ```Docker```, ```REX-Ray``` is easily integrated into any workflow. For example, here's how to list storage for a guest hosted on Amazon Web Services (AWS) with ```REX-Ray```:
 
 ```bash
@@ -23,12 +23,54 @@
 [0]akutz@pax:~$
 ```
 
-# Downloading
-It's easy to download pre-build binaries for REX-Ray:
+# Installation
+Installing `REX-Ray` couldn't be easier.
 
-* Stupid - [ ![Download](https://api.bintray.com/packages/emccode/rexray/stupid/images/download.svg) ](https://dl.bintray.com/emccode/rexray/stupid/latest/)
-* Staged - [ ![Download](https://api.bintray.com/packages/emccode/rexray/staged/images/download.svg) ](https://dl.bintray.com/emccode/rexray/staged/latest/)
-* Stable - [ ![Download](https://api.bintray.com/packages/emccode/rexray/stable/images/download.svg) ](https://dl.bintray.com/emccode/rexray/stable/latest/)
+```bash
+curl -sSL https://dl.bintray.com/emccode/rexray/install | sh -
+```
+
+On Linux systems the above command will download `REX-Ray` and install it at `/usr/bin/rexray` and register it as a SystemV or SystemD service depending on what the Linux distribution supports. On Darwin (OS X) systems the binary is installed at `/usr/bin/rexray` sans service registration.
+
+# Downloading
+There are also pre-built binaries at the following locations:
+
+Repository | Version | Description
+---------- | ------- | -----------
+[unstable](https://dl.bintray.com/emccode/rexray/stupid) | [ ![Download](https://api.bintray.com/packages/emccode/rexray/stupid/images/download.svg) ](https://dl.bintray.com/emccode/rexray/stupid/latest/) | The most up-to-date, bleeding-edge, and often unstable REX-Ray binaries.
+[staged](https://dl.bintray.com/emccode/rexray/staged)   | [ ![Download](https://api.bintray.com/packages/emccode/rexray/staged/images/download.svg) ](https://dl.bintray.com/emccode/rexray/staged/latest/) | The most up-to-date, release candidate REX-Ray binaries.
+[stable](https://dl.bintray.com/emccode/rexray/stable)   | [ ![Download](https://api.bintray.com/packages/emccode/rexray/stable/images/download.svg) ](https://dl.bintray.com/emccode/rexray/stable/latest/) | The most up-to-date, stable REX-Ray binaries.
+
+# Building
+`REX-Ray` is also fairly simple to build from source, especially if you have `Docker` installed:
+
+```bash
+SRC=$(mktemp -d 2> /dev/null || mktemp -d -t rexray 2> /dev/null) && cd $SRC && docker run --rm -it -v $SRC:/usr/src/rexray -w /usr/src/rexray golang:1.5.1 bash -c "git clone https://github.com/emccode/rexray.git . && make build-all”
+```
+
+If you'd prefer to not use `Docker` to build `REX-Ray` then all you need is Go 1.5:
+
+```bash
+# clone the rexray repo
+git clone https://github.com/emccode/rexray.git
+
+# change directories into the freshly-cloned repo
+cd rexray
+
+# build rexray
+make build-all
+```
+
+After either of the above methods for building `REX-Ray` there should be a `.bin` directory in the
+current directory, and inside `.bin` will be binaries for Linux-i386, Linux-x86-64, 
+and Darwin-x86-64.
+
+```bash
+[0]akutz@poppy:tmp.SJxsykQwp7$ ls .bin/*/rexray
+-rwxr-xr-x. 1 root 14M Sep 17 10:36 .bin/Darwin-x86_64/rexray*
+-rwxr-xr-x. 1 root 12M Sep 17 10:36 .bin/Linux-i386/rexray*
+-rwxr-xr-x. 1 root 14M Sep 17 10:36 .bin/Linux-x86_64/rexray*
+```
 
 # State
 We have a first release available that support all of the following capabilities!  


### PR DESCRIPTION
This patch updates the README with instructions on how to install, download, and build REX-Ray. @clintonskitson, please review the [updated README](https://github.com/akutz/rexray/tree/feature/getting-rexray-updates) and provide feedback and/or merge this PR. Thanks!