### PR TITLE
Makefile RPM Change Directories Fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,6 +292,7 @@ rpm: install
 		$(CWD)/rexray.spec > $(RPMBUILD)/SPECS/rexray.spec
 
 	@printf "  ...building rpm..."; \
+		cd $(RPMBUILD); \
 		rpmbuild -ba --quiet SPECS/rexray.spec; \
 		$(PRINT_STATUS); \
 		if [ "$$EC" -eq "0" ]; then \


### PR DESCRIPTION
This patch updates the Makefile `rpm` target with a piece of missing
logic. Prior to executing the `rpm` build, the current directory is
changed to `$(RPMBUILD)`.