### PR TITLE
Env Vars in `/etc/environment` no longer override

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -247,7 +247,7 @@ func loadEtcEnvironment() {
 	}
 	for l := range lr {
 		m := envVarRx.FindStringSubmatch(l)
-		if m == nil {
+		if m == nil || len(m) < 3 || os.Getenv(m[1]) != "" {
 			continue
 		}
 		os.Setenv(m[1], m[2])


### PR DESCRIPTION
This patch fixes an issue (#40) where the environment variables present in `/etc/environment` would override any other environment variable set by any other means. This is no longer the case.

The easiest way to test this is to edit `/etc/environment` to include `REXRAY_LOGLEVEL=debug` and then run `rexray version`. You'll see something similar to the following:

    [0]akutz@pax:rexray$ rexray version
    DEBU[0000] updated log level        logLevel=debug
    DEBU[0000] usage template path      path=/Users/akutz/.rexray/usage.template
    DEBU[0000] loaded usage template    source=UsageTemplate
    DEBU[0000] updated log level        logLevel=debug
    SemVer: 0.2.0-rc5+5+dirty
    Binary: Darwin-x86_64
    Branch: bugfix/etc-environment-order
    Commit: c8158f6a345a5c9e9f2c1018eab2f371ee557eea
    Formed: Mon, 21 Sep 2015 13:33:47 CDT

However, if you specify `REXRAY_LOGLEVEL=info` on the command-line:

    [0]akutz@pax:rexray$ env REXRAY_LOGLEVEL=info rexray version
    SemVer: 0.2.0-rc5+5+dirty
    Binary: Darwin-x86_64
    Branch: bugfix/etc-environment-order
    Commit: c8158f6a345a5c9e9f2c1018eab2f371ee557eea
    Formed: Mon, 21 Sep 2015 13:33:47 CDT

As demonstrated above, the environment variable value specified on the command line has a higher order of precedence than the one specified in the file `/etc/environment`.