### PR TITLE
Repo-Specific Install Scripts

### DIFF
--- a/install-staged
+++ b/install-staged
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# install rexray with the following command:
+#
+#   curl -sSL https://dl.bintray.com/emccode/rexray/install | sh -
+
+# get the real installer -- the current file is just an abstraction to maintain
+# a consistent download count for installs via the curl install method
+curl -sSL https://raw.githubusercontent.com/emccode/rexray/master/install.sh | sh -s staged -

--- a/install-unstable
+++ b/install-unstable
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# install rexray with the following command:
+#
+#   curl -sSL https://dl.bintray.com/emccode/rexray/install | sh -
+
+# get the real installer -- the current file is just an abstraction to maintain
+# a consistent download count for installs via the curl install method
+curl -sSL https://raw.githubusercontent.com/emccode/rexray/master/install.sh | sh -s unstable -

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-URL=https://dl.bintray.com/emccode/rexray/staged/latest
+REPO="${1:-staged}"
+URL=https://dl.bintray.com/emccode/rexray/$REPO/latest
 ARCH=$(uname -m)
 
 # how to detect the linux distro was taken from http://bit.ly/1JkNwWx


### PR DESCRIPTION
The `install.sh` file can now accept a single parameter to indicate the repository from which to fetch the binaries. Valid values are `unstable`, `staged`, and `stable`. The default value is `staged` for now, and then when version 0.2.0 is released this will be changed to `stable`.