### PR TITLE
Spf13 Vendoring Update

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -134,7 +134,7 @@ func New() *Config {
 
 func (c *Config) Copy() (*Config, error) {
 	newC := New()
-	mErr := c.Viper.Marshal(newC)
+	mErr := c.Viper.Unmarshal(newC)
 	if mErr != nil {
 		return nil, mErr
 	}

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,10 +3,6 @@ import:
   - package: github.com/spf13/pflag
     repo:    https://github.com/spf13/pflag
     vcs:     git
-  - package: github.com/spf13/viper
-    repo:    https://github.com/akutz/viper
-    ref:     support/typed-vars-plfag-defaults
-    vcs:     git
   - package: github.com/spf13/cobra
     repo:    https://github.com/akutz/cobra
     ref:     feature/rexray

--- a/rexray/cli/usage.go
+++ b/rexray/cli/usage.go
@@ -146,7 +146,7 @@ Aliases:
   {{.NameAndAliases | rtrim}}{{end}}{{if .HasExample}}
 
 Examples:
-{{.Example | rtrim}}{{end}}{{ if .HasNonHelpSubCommands}}
+{{.Example | rtrim}}{{end}}{{ if .HasAvailableSubCommands}}
 
 Available Commands: {{range cmds $cmd}}{{if (not .IsHelpCommand)}}
   {{rpad .Name .NamePadding }} {{.Short | rtrim}}{{end}}{{end}}{{end}}{{$lf := lf $cmd}}{{if hf $lf}}


### PR DESCRIPTION
This patch updates the vendoring of REX-Ray with regards to the Spf13 projects Viper and Cobra. The vendored Viper dependency was removed as the pull request for the required feature was accepted into Viper master. The vendored Cobra reference remains, but the Cobra fork was rebased off of its master and necessary changes were made to REX-Ray to accommodate the changes to Cobra.