### PR TITLE
Log File and Stdout

### DIFF
--- a/rexray/cli/flags.go
+++ b/rexray/cli/flags.go
@@ -36,6 +36,8 @@ func initServiceFlags() {
 		"Starts the service in the foreground")
 	serviceStartCmd.Flags().StringVarP(&client, "client", "", "",
 		"Socket the daemon uses to communicate to the client")
+	serviceStartCmd.Flags().BoolVarP(&force, "force", "", false,
+		"Forces the service to start, ignoring errors")
 }
 
 func initInstallerFlags() {

--- a/rexray/cli/rexray.go
+++ b/rexray/cli/rexray.go
@@ -42,6 +42,7 @@ var (
 
 	client                  string
 	fg                      bool
+	force                   bool
 	cfgFile                 string
 	snapshotID              string
 	volumeID                string
@@ -229,9 +230,6 @@ func printNonColorizedError(err error) {
 
 func isInitDriverManagersCmd(cmd *cobra.Command) bool {
 
-	isClient, _ := cmd.Flags().GetBool("client")
-	isForeground, _ := cmd.Flags().GetBool("foreground")
-
 	return cmd.Parent() != nil &&
 		cmd != adapterCmd &&
 		cmd != adapterGetTypesCmd &&
@@ -242,7 +240,7 @@ func isInitDriverManagersCmd(cmd *cobra.Command) bool {
 		cmd != uninstallCmd &&
 		cmd != serviceStatusCmd &&
 		cmd != serviceStopCmd &&
-		!(cmd == serviceStartCmd && (isClient || isForeground)) &&
+		!(cmd == serviceStartCmd && (client != "" || fg || force)) &&
 		cmd != moduleCmd &&
 		cmd != moduleTypesCmd &&
 		cmd != moduleInstancesCmd &&

--- a/rexray/cli/service.go
+++ b/rexray/cli/service.go
@@ -178,7 +178,6 @@ func tryToStartDaemon() {
 	}
 
 	cmd := exec.Command(thisAbsPath, cmdArgs...)
-	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
 	cmdErr := cmd.Start()


### PR DESCRIPTION
This patch fixes an issue (#79) where the log file was not getting created if the service was started while attached to a TTY. Now when the service is started the log file should be created at `/var/log/rexray/rexray.log` without issue.