### PR TITLE
Uninstaller Uses Pkg Manager Where Appropriate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,15 +181,17 @@ _post-make:
 
 deps: _pre-make _deps _post-make
 _deps: 
-	@echo "target: deps"
-	@printf "  ...installing glide..."
-	@go get github.com/Masterminds/glide; \
-		$(PRINT_STATUS)
-	@printf "  ...downloading go dependencies..."; \
-		cd $(BASEDIR); \
-		go get -d $(GOFLAGS) $(NV); \
-		$(GLIDE) -q up 2> /dev/null; \
-		$(PRINT_STATUS)
+	@if [ -z "$$OFFLINE" ]; then \
+		echo "target: deps"; \
+		printf "  ...installing glide..."; \
+		go get github.com/Masterminds/glide; \
+			$(PRINT_STATUS); \
+		printf "  ...downloading go dependencies..."; \
+			cd $(BASEDIR); \
+			go get -d $(GOFLAGS) $(NV); \
+			$(GLIDE) -q up 2> /dev/null; \
+			$(PRINT_STATUS); \
+	fi
 
 build: _pre-make _build _post-make
 _build: _deps _fmt build_
@@ -349,6 +351,7 @@ rpm:
 			FILE=$$(readlink -f $$(find $(RPMBUILD)/RPMS -name *.rpm)); \
 			DEPLOY_FILE=.deploy/$(V_OS_ARCH)/$$(basename $$FILE); \
 			mkdir -p .deploy/$(V_OS_ARCH); \
+			rm -f .deploy/$(V_OS_ARCH)/*.rpm; \
 			mv -f $$FILE $$DEPLOY_FILE; \
 			FILE=$$DEPLOY_FILE; \
 			cp -f $$FILE .deploy/latest/rexray-latest-$(V_ARCH).rpm; \
@@ -374,6 +377,7 @@ deb:
 	@echo "target: deb"
 	@printf "  ...building deb $(V_ARCH)..."; \
 		cd .deploy/$(V_OS_ARCH); \
+		rm -f *.deb; \
 		fakeroot alien -k -c --bump=0 *.rpm > /dev/null; \
 		$(PRINT_STATUS); \
 		if [ "$$EC" -eq "0" ]; then \

--- a/rexray/cli/commands.go
+++ b/rexray/cli/commands.go
@@ -109,6 +109,8 @@ var versionCmd = &cobra.Command{
 		}
 		buildDate := time.Unix(epochInt, 0)
 
+		_, _, exeFile := util.GetThisPathParts()
+		fmt.Printf("%s\n\n", exeFile)
 		fmt.Printf("SemVer: %s\n", version.SemVer)
 		fmt.Printf("Binary: %s\n", version.Arch)
 		fmt.Printf("Branch: %s\n", version.Branch)

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -18,3 +18,51 @@ func TestStringInSlice(t *testing.T) {
 		t.Fatal("hi where?")
 	}
 }
+
+func TestTrimSingleWord(t *testing.T) {
+
+	s := Trim(`    
+		
+						hi       
+						
+						
+		      
+		      
+    `)
+
+	if s != "hi" {
+		t.Fatalf("trim failed '%v'", s)
+	}
+}
+
+func TestTrimMultipleWords(t *testing.T) {
+
+	s := Trim(`    
+		
+						hi       
+						
+		there				
+		      
+		     you 
+    `)
+
+	if s != `hi       
+						
+		there				
+		      
+		     you` {
+		t.Fatalf("trim failed '%v'", s)
+	}
+}
+
+func TestFileExists(t *testing.T) {
+	if !FileExists("/bin/sh") {
+		t.Fail()
+	}
+}
+
+func TestFileExistsInPath(t *testing.T) {
+	if !FileExistsInPath("sh") {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
This patch fixes an issue (#78) whereby when REX-Ray was uninstalled with `rexray uninstall`, the RPM or DEB manager would be left in a corrupt state if those were used to install REX-Ray. This update instructs the uninstall command to use the package manager for uninstallation where appropriate.

## CentOS 7
```
[1]akutz@poppy:rexray$ sudo rexray uninstall -l debug
DEBU[0000] updated log level                             logLevel=debug
DEBU[0000] is this a managed file?                       binFile=/usr/bin/rexray
DEBU[0000] rpm install query result                      output=rexray-0.2.0+rc5+19+dirty-1.x86_64

DEBU[0000] is rpm install success                        exePath=/usr/bin/rexray pkgName=rexray-0.2.0+rc5+19+dirty-1.x86_64

[0]akutz@poppy:rexray$ which rexray
/usr/bin/which: no rexray in (/home/akutz/.gem/ruby/gems/travis-1.8.0/bin:/opt/git/2.4.8/bin:/opt/git/2.4.8/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/akutz/go/bin:/home/akutz/goroot/bin)

[1]akutz@poppy:rexray$ 
```

## Ubuntu 14.04
```
[0]akutz@ubuntu:rexray$ sudo dpkg -i .deploy/Linux-x86_64/rexray_0.2.0+rc5+19+dirty-1_amd64.deb 
Selecting previously unselected package rexray.
(Reading database ... 65609 files and directories currently installed.)
Preparing to unpack .../rexray_0.2.0+rc5+19+dirty-1_amd64.deb ...
Unpacking rexray (0.2.0+rc5+19+dirty-1) ...
Setting up rexray (0.2.0+rc5+19+dirty-1) ...

[0]akutz@ubuntu:rexray$ sudo rexray uninstall -l debug
DEBU[0000] updated log level                             logLevel=debug
DEBU[0000] is this a managed file?                       binFile=/usr/bin/rexray
DEBU[0000] error checking if rpm install                 error=exit status 1 exePath=/usr/bin/rexray output=file /usr/bin/rexray is not owned by any package

DEBU[0000] deb install query result                      output=rexray: /usr/bin/rexray

DEBU[0000] is deb install success                        exePath=/usr/bin/rexray pkgName=rexray
```

Here is another example on Ubuntu where `uninstall` is invoked against a `rexray` binary, but *not* the one controlled by the package manager.

```
[0]akutz@ubuntu:rexray$ sudo dpkg -i .deploy/Linux-x86_64/rexray_0.2.0+rc5+19+dirty-1_amd64.deb 
Selecting previously unselected package rexray.
(Reading database ... 65609 files and directories currently installed.)
Preparing to unpack .../rexray_0.2.0+rc5+19+dirty-1_amd64.deb ...
Unpacking rexray (0.2.0+rc5+19+dirty-1) ...
Setting up rexray (0.2.0+rc5+19+dirty-1) ...

[0]akutz@ubuntu:rexray$ sudo $GOPATH/bin/rexray uninstall -l debug
DEBU[0000] updated log level                             logLevel=debug
DEBU[0000] is this a managed file?                       binFile=/home/akutz/go/bin/rexray
DEBU[0000] error checking if rpm install                 error=exit status 1 exePath=/home/akutz/go/bin/rexray output=file /home/akutz/go/bin/rexray is not owned by any package

DEBU[0000] error checking if deb install                 error=exit status 1 exePath=/home/akutz/go/bin/rexray output=dpkg-query: no path found matching pattern /home/akutz/go/bin/rexray
```