### PR TITLE
Binary & Version Info Logged on Service Start

### DIFF
--- a/rexray/cli/commands.go
+++ b/rexray/cli/commands.go
@@ -5,13 +5,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"strconv"
-	"time"
+	"os"
 
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/emccode/rexray/util"
-	version "github.com/emccode/rexray/version_info"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v1"
 )
@@ -102,20 +100,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version",
 	Run: func(cmd *cobra.Command, args []string) {
-
-		epochInt, epochIntErr := strconv.ParseInt(version.Epoch, 10, 64)
-		if epochIntErr != nil {
-			panic(epochIntErr)
-		}
-		buildDate := time.Unix(epochInt, 0)
-
-		_, _, exeFile := util.GetThisPathParts()
-		fmt.Printf("%s\n\n", exeFile)
-		fmt.Printf("SemVer: %s\n", version.SemVer)
-		fmt.Printf("Binary: %s\n", version.Arch)
-		fmt.Printf("Branch: %s\n", version.Branch)
-		fmt.Printf("Commit: %s\n", version.ShaLong)
-		fmt.Printf("Formed: %s\n", buildDate.Format(time.RFC1123))
+		util.PrintVersion(os.Stdout)
 	},
 }
 

--- a/rexray/cli/service.go
+++ b/rexray/cli/service.go
@@ -59,6 +59,8 @@ func startDaemon() {
 	log.SetOutput(out)
 
 	fmt.Fprintf(out, "%s\n", RexRayLogoAscii)
+	util.PrintVersion(out)
+	fmt.Fprintln(out)
 
 	var success []byte
 	var failure []byte

--- a/util/util.go
+++ b/util/util.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/emccode/rexray/errors"
+	version "github.com/emccode/rexray/version_info"
 	"github.com/kardianos/osext"
 )
 
@@ -41,6 +42,10 @@ const (
 var (
 	trimRx    *regexp.Regexp
 	netAddrRx *regexp.Regexp
+
+	thisExeDir     string
+	thisExeName    string
+	thisExeAbsPath string
 
 	prefix string
 
@@ -68,6 +73,8 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+
+	thisExeDir, thisExeName, thisExeAbsPath = GetThisPathParts()
 }
 
 func GetPrefix() string {
@@ -376,4 +383,13 @@ func Trim(text string) string {
 		return text
 	}
 	return m[1]
+}
+
+func PrintVersion(out io.Writer) {
+	fmt.Fprintf(out, "Binary: %s\n", thisExeAbsPath)
+	fmt.Fprintf(out, "SemVer: %s\n", version.SemVer)
+	fmt.Fprintf(out, "OsArch: %s\n", version.Arch)
+	fmt.Fprintf(out, "Branch: %s\n", version.Branch)
+	fmt.Fprintf(out, "Commit: %s\n", version.ShaLong)
+	fmt.Fprintf(out, "Formed: %s\n", version.EpochToRfc1123())
 }

--- a/version_info/version_info.go
+++ b/version_info/version_info.go
@@ -1,9 +1,36 @@
 package version_info
 
+import (
+	"strconv"
+	"time"
+)
+
 var (
 	SemVer  string
 	ShaLong string
 	Epoch   string
 	Branch  string
 	Arch    string
+
+	epoch     int64
+	buildDate time.Time
 )
+
+func init() {
+	if Epoch == "" {
+		return
+	}
+	var err error
+	epoch, err = strconv.ParseInt(Epoch, 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	buildDate = time.Unix(epoch, 0)
+}
+
+func EpochToRfc1123() string {
+	if Epoch == "" {
+		return ""
+	}
+	return buildDate.Format(time.RFC1123)
+}


### PR DESCRIPTION
The REX-Ray binary and version information is now logged to the log file (or console if in foreground mode) when the service is started to account for issue #83. The output will resemble the following:

```
                 ╙Ω▀█ ▓██ⁿ    └█▀██▀▓█├█Å
                     ⁿⁿ             ⁿ ⁿ^
:::::::..  .,::::::    .,::      .::::::::..    :::.  .-:.     ::-.
;;;;'';;;; ;;;;''''    ';;;,  .,;; ;;;;'';;;;   ;;';;  ';;.   ;;;;'
 [[[,/[[['  [[cccc       '[[,,[['   [[[,/[[['  ,[[ '[[,  '[[,[[['
 $$$$$$c    $$""""        Y$$$Pcccc $$$$$$c   c$$$cc$$$c   c$$"
 888b "88bo,888oo,__    oP"''"Yo,   888b "88bo,888   888,,8P"'
 MMMM   "W" """"YUMMM,m"       "Mm, MMMM   "W" YMM   ""'mM"

Binary: /home/akutz/go/bin/rexray
SemVer: 0.2.0-rc5+27+dirty
OsArch: Linux-x86_64
Branch: feature/log-version
Commit: 8c5b579b8e727460cd374e535469a5fb75dca2e2
Formed: Mon, 28 Sep 2015 14:37:36 CDT

time="2015-09-28T14:40:39-05:00" level=info msg="dialing /tmp/ZSPQHcKuS
```