### PR TITLE
A yaml by any other name...yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Available Commands:
   help        Help about any command
 
 Flags:
-  -c, --config="$HOME/.rexray/config.yaml": The REX-Ray configuration file
+  -c, --config="$HOME/.rexray/config.yml": The REX-Ray configuration file
   -d, --debug=false: Enables verbose output
   -?, --help=false: Help for rexray
   -h, --host="tcp://127.0.0.1:7979": The REX-Ray service address

--- a/rexray/cli/flags.go
+++ b/rexray/cli/flags.go
@@ -22,7 +22,7 @@ func initFlags() {
 
 func initGlobalFlags() {
 	RexrayCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c",
-		fmt.Sprintf("%s/.rexray/config.yaml", util.HomeDir()),
+		fmt.Sprintf("%s/.rexray/config.yml", util.HomeDir()),
 		"The REX-Ray configuration file")
 	RexrayCmd.PersistentFlags().BoolP(
 		"verbose", "v", false, "Print verbose help information")


### PR DESCRIPTION
This patch changes the extension 'yaml' in the README.md file as well as in the flag text when executing REX-Ray as a CLI program.

This PR closes the loop on issue #86.