### PR TITLE
Added error logging to volume driver manager methods

### DIFF
--- a/volume/volume.go
+++ b/volume/volume.go
@@ -93,7 +93,12 @@ func (vdm *VolumeDriverManager) Mount(volumeName, volumeID string, overwriteFs b
 			"overwriteFs": overwriteFs,
 			"newFsType":   newFsType,
 			"driverName":  driver.Name()}).Info("mounting volume")
-		return driver.Mount(volumeName, volumeID, overwriteFs, newFsType)
+		output, err := driver.Mount(volumeName, volumeID, overwriteFs, newFsType)
+		if err != nil {
+			log.Error(err)
+			return "", err
+		}
+		return output, nil
 	}
 	return "", errors.New("no volume manager specified")
 }
@@ -104,7 +109,12 @@ func (vdm *VolumeDriverManager) Unmount(volumeName, volumeID string) error {
 			"volumeName": volumeName,
 			"volumeID":   volumeID,
 			"driverName": driver.Name()}).Info("unmounting volume")
-		return driver.Unmount(volumeName, volumeID)
+		err := driver.Unmount(volumeName, volumeID)
+		if err != nil {
+			log.Error(err)
+			return err
+		}
+		return nil
 	}
 	return errors.New("no volume manager specified")
 }
@@ -115,7 +125,12 @@ func (vdm *VolumeDriverManager) Path(volumeName, volumeID string) (string, error
 			"volumeName": volumeName,
 			"volumeID":   volumeID,
 			"driverName": driver.Name()}).Info("path of volume")
-		return driver.Path(volumeName, volumeID)
+		output, err := driver.Path(volumeName, volumeID)
+		if err != nil {
+			log.Error(err)
+			return "", err
+		}
+		return output, nil
 	}
 	return "", errors.New("no volume manager specified")
 }
@@ -126,7 +141,12 @@ func (vdm *VolumeDriverManager) Create(volumeName string, volumeOpts VolumeOpts)
 			"volumeName": volumeName,
 			"volumeOpts": volumeOpts,
 			"driverName": driver.Name()}).Info("create volume")
-		return driver.Create(volumeName, volumeOpts)
+		err := driver.Create(volumeName, volumeOpts)
+		if err != nil {
+			log.Error(err)
+			return err
+		}
+		return nil
 	}
 	return errors.New("no volume manager specified")
 }
@@ -136,7 +156,12 @@ func (vdm *VolumeDriverManager) Remove(volumeName string) error {
 		log.WithFields(log.Fields{
 			"volumeName": volumeName,
 			"driverName": driver.Name()}).Info("remove volume")
-		return driver.Remove(volumeName)
+		err := driver.Remove(volumeName)
+		if err != nil {
+			log.Error(err)
+			return err
+		}
+		return nil
 	}
 	return errors.New("no volume manager specified")
 }
@@ -147,7 +172,12 @@ func (vdm *VolumeDriverManager) Attach(volumeName, instanceID string) (string, e
 			"volumeName": volumeName,
 			"instanceID": instanceID,
 			"driverName": driver.Name()}).Info("attach volume")
-		return driver.Attach(volumeName, instanceID)
+		output, err := driver.Attach(volumeName, instanceID)
+		if err != nil {
+			log.Error(err)
+			return "", err
+		}
+		return output, nil
 	}
 	return "", errors.New("no volume manager specified")
 }
@@ -158,7 +188,12 @@ func (vdm *VolumeDriverManager) Detach(volumeName, instanceID string) error {
 			"volumeName": volumeName,
 			"instanceID": instanceID,
 			"driverName": driver.Name()}).Info("detach volume")
-		return driver.Detach(volumeName, instanceID)
+		err := driver.Detach(volumeName, instanceID)
+		if err != nil {
+			log.Error(err)
+			return err
+		}
+		return nil
 	}
 	return errors.New("no volume manager specified")
 }
@@ -169,7 +204,12 @@ func (vdm *VolumeDriverManager) NetworkName(volumeName, instanceID string) (stri
 			"volumeName": volumeName,
 			"instanceID": instanceID,
 			"driverName": driver.Name()}).Info("get network name")
-		return driver.NetworkName(volumeName, instanceID)
+		output, err := driver.NetworkName(volumeName, instanceID)
+		if err != nil {
+			log.Error(err)
+			return "", err
+		}
+		return output, nil
 	}
 	return "", errors.New("no volume manager specified")
 }


### PR DESCRIPTION
The errors created from the methods in the volume driver manager were not previously being reported into the logging mechanism.  The methods were updated to report now to the log package and continue to report back through normal returns.