### PR TITLE
Set default settings for new volumes from existing are from orig

### DIFF
--- a/core/config/config_keymap.go
+++ b/core/config/config_keymap.go
@@ -169,7 +169,7 @@ func initConfigKeyMap() {
 
 		DockerVolumeType:       ck("REXRAY_DOCKER_VOLUMETYPE", "", ""),
 		DockerIOPS:             ck("REXRAY_DOCKER_IOPS", 0, ""),
-		DockerSize:             ck("REXRAY_DOCKER_SIZE", 16, ""),
+		DockerSize:             ck("REXRAY_DOCKER_SIZE", 0, ""),
 		DockerAvailabilityZone: ck("REXRAY_DOCKER_AVAILABILITYZONE", "", ""),
 
 		AwsAccessKey: ck("AWS_ACCESS_KEY", "", ""),

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -77,8 +77,8 @@ func TestAssertConfigDefaults(t *testing.T) {
 		t.Fatalf("c.VolumeDrivers != []string{\"docker\"}, == %v", c.VolumeDrivers)
 	}
 
-	if c.DockerSize != 16 {
-		t.Fatalf("c.DockerSize != 16, == %d", c.DockerSize)
+	if c.DockerSize != 0 {
+		t.Fatalf("c.DockerSize != 0, == %d", c.DockerSize)
 	}
 }
 


### PR DESCRIPTION
This commit ensures that volumes created from existing snapshots
or volumes are configured with the same defaults.  For volumes,
the VolumeType, IOPS, and Size are replicated.  For snaphshots,
the Size is replicated.  The parameters to override this are
standard volume creation options.

Satisfies feedback from https://github.com/emccode/rexray/issues/124 and https://github.com/emccode/rexray/issues/129
