### PR TITLE
Added --format,-f option for CLI

### DIFF
--- a/rexray/cli/commands.go
+++ b/rexray/cli/commands.go
@@ -1,11 +1,13 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -386,11 +388,11 @@ var adapterGetInstancesCmd = &cobra.Command{
 		}
 
 		if len(allInstances) > 0 {
-			yamlOutput, err := yaml.Marshal(&allInstances)
+			out, err := marshalOutput(&allInstances)
 			if err != nil {
 				log.Fatal(err)
 			}
-			fmt.Printf(string(yamlOutput))
+			fmt.Println(out)
 		}
 	},
 }
@@ -406,11 +408,11 @@ var volumeMapCmd = &cobra.Command{
 		}
 
 		if len(allBlockDevices) > 0 {
-			yamlOutput, err := yaml.Marshal(&allBlockDevices)
+			out, err := marshalOutput(&allBlockDevices)
 			if err != nil {
 				log.Fatal(err)
 			}
-			fmt.Printf(string(yamlOutput))
+			fmt.Println(out)
 		}
 	},
 }
@@ -427,11 +429,11 @@ var volumeGetCmd = &cobra.Command{
 		}
 
 		if len(allVolumes) > 0 {
-			yamlOutput, err := yaml.Marshal(&allVolumes)
+			out, err := marshalOutput(&allVolumes)
 			if err != nil {
 				log.Fatal(err)
 			}
-			fmt.Printf(string(yamlOutput))
+			fmt.Println(out)
 		}
 	},
 }
@@ -448,11 +450,11 @@ var snapshotGetCmd = &cobra.Command{
 		}
 
 		if len(allSnapshots) > 0 {
-			yamlOutput, err := yaml.Marshal(&allSnapshots)
+			out, err := marshalOutput(&allSnapshots)
 			if err != nil {
 				log.Fatal(err)
 			}
-			fmt.Printf(string(yamlOutput))
+			fmt.Println(out)
 		}
 	},
 }
@@ -472,11 +474,11 @@ var snapshotCreateCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		yamlOutput, err := yaml.Marshal(&snapshot)
+		out, err := marshalOutput(&snapshot)
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf(string(yamlOutput))
+		fmt.Println(out)
 
 	},
 }
@@ -516,11 +518,11 @@ var volumeCreateCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		yamlOutput, err := yaml.Marshal(&volume)
+		out, err := marshalOutput(&volume)
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf(string(yamlOutput))
+		fmt.Println(out)
 
 	},
 }
@@ -557,11 +559,11 @@ var volumeAttachCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		yamlOutput, err := yaml.Marshal(&volumeAttachment)
+		out, err := marshalOutput(&volumeAttachment)
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf(string(yamlOutput))
+		fmt.Println(out)
 
 	},
 }
@@ -599,11 +601,11 @@ var snapshotCopyCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		yamlOutput, err := yaml.Marshal(&snapshot)
+		out, err := marshalOutput(&snapshot)
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf(string(yamlOutput))
+		fmt.Println(out)
 
 	},
 }
@@ -619,11 +621,11 @@ var deviceGetCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		yamlOutput, err := yaml.Marshal(&mounts)
+		out, err := marshalOutput(&mounts)
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf(string(yamlOutput))
+		fmt.Println(out)
 	},
 }
 
@@ -697,11 +699,11 @@ var volumeMountCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		yamlOutput, err := yaml.Marshal(&mountPath)
+		out, err := marshalOutput(&mountPath)
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf(string(yamlOutput))
+		fmt.Println(out)
 
 	},
 }
@@ -738,11 +740,33 @@ var volumePathCmd = &cobra.Command{
 		}
 
 		if mountPath != "" {
-			yamlOutput, err := yaml.Marshal(&mountPath)
+			out, err := marshalOutput(&mountPath)
 			if err != nil {
 				log.Fatal(err)
 			}
-			fmt.Printf(string(yamlOutput))
+			fmt.Println(out)
 		}
 	},
+}
+
+func marshalOutput(v interface{}) (string, error) {
+	var err error
+	var buf []byte
+	if strings.ToUpper(outputFormat) == "JSON" {
+		buf, err = marshalJSONOutput(v)
+	} else {
+		buf, err = marshalYamlOutput(v)
+	}
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+func marshalYamlOutput(v interface{}) ([]byte, error) {
+	return yaml.Marshal(v)
+}
+
+func marshalJSONOutput(v interface{}) ([]byte, error) {
+	return json.Marshal(v)
 }

--- a/rexray/cli/flags.go
+++ b/rexray/cli/flags.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/emccode/rexray/util"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func initFlags() {
@@ -71,6 +72,14 @@ func initVolumeFlags() {
 	volumeUnmountCmd.Flags().StringVar(&volumeName, "volumename", "", "volumename")
 	volumePathCmd.Flags().StringVar(&volumeID, "volumeid", "", "volumeid")
 	volumePathCmd.Flags().StringVar(&volumeName, "volumename", "", "volumename")
+
+	addOutputFormatFlag(volumeCmd.Flags())
+	addOutputFormatFlag(volumeGetCmd.Flags())
+	addOutputFormatFlag(volumeCreateCmd.Flags())
+	addOutputFormatFlag(volumeAttachCmd.Flags())
+	addOutputFormatFlag(volumeMountCmd.Flags())
+	addOutputFormatFlag(volumePathCmd.Flags())
+	addOutputFormatFlag(volumeMapCmd.Flags())
 }
 
 func initDeviceFlags() {
@@ -84,6 +93,9 @@ func initDeviceFlags() {
 	deviceFormatCmd.Flags().StringVar(&deviceName, "devicename", "", "devicename")
 	deviceFormatCmd.Flags().StringVar(&fsType, "fstype", "", "fstype")
 	deviceFormatCmd.Flags().BoolVar(&overwriteFs, "overwritefs", false, "overwritefs")
+
+	addOutputFormatFlag(deviceCmd.Flags())
+	addOutputFormatFlag(deviceGetCmd.Flags())
 }
 
 func initSnapshotFlags() {
@@ -101,6 +113,11 @@ func initSnapshotFlags() {
 	snapshotCopyCmd.Flags().StringVar(&snapshotName, "snapshotname", "", "snapshotname")
 	snapshotCopyCmd.Flags().StringVar(&destinationSnapshotName, "destinationsnapshotname", "", "destinationsnapshotname")
 	snapshotCopyCmd.Flags().StringVar(&destinationRegion, "destinationregion", "", "destinationregion")
+
+	addOutputFormatFlag(snapshotCmd.Flags())
+	addOutputFormatFlag(snapshotGetCmd.Flags())
+	addOutputFormatFlag(snapshotCopyCmd.Flags())
+	addOutputFormatFlag(snapshotCreateCmd.Flags())
 }
 
 func initModuleFlags() {
@@ -122,4 +139,13 @@ func initModuleFlags() {
 
 	moduleInstancesStartCmd.Flags().Int32VarP(&moduleInstanceID, "id",
 		"i", -1, "The ID of the module instance to start")
+}
+
+func initAdapterFlags() {
+	addOutputFormatFlag(adapterGetInstancesCmd.Flags())
+}
+
+func addOutputFormatFlag(fs *pflag.FlagSet) {
+	fs.StringVarP(
+		&outputFormat, "format", "f", "yml", "The output format (yml, json)")
 }

--- a/rexray/cli/rexray.go
+++ b/rexray/cli/rexray.go
@@ -33,6 +33,7 @@ const (
 var (
 	r *core.RexRay
 
+	outputFormat            string
 	client                  string
 	fg                      bool
 	force                   bool


### PR DESCRIPTION
This patch addresses issue #135 and adds the flag `--format` or `-f` for the following CLI commands:

  * adapter instances
  * device [get]
  * snapshot [get]
  * snapshot copy
  * snapshot create
  * volume [get]
  * volume attach
  * volume create
  * volume map
  * volume mount
  * volume path

The user can specify either `--format=yml|yaml|json` or `-f yml|yaml|json` in order to influence how the resulting, structured data is marshaled prior to being emitted to the console.

The default output value is `yml`.