### PR TITLE
fixed typo in snapshot/copy command

### DIFF
--- a/rexray/cli/commands.go
+++ b/rexray/cli/commands.go
@@ -587,7 +587,7 @@ var volumeDetachCmd = &cobra.Command{
 
 var snapshotCopyCmd = &cobra.Command{
 	Use:   "copy",
-	Short: "Copie a snapshot",
+	Short: "Copies a snapshot",
 	Run: func(cmd *cobra.Command, args []string) {
 
 		if snapshotID == "" && volumeID == "" && volumeName == "" {


### PR DESCRIPTION
the short version said 'Copie a snapshot', i just changed it to 'Copies'

Signed-off-by: Kendrick Coleman <kendrickcoleman@gmail.com>