### PR TITLE
Bugfix for Config.ToJSON getting just private info

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -217,7 +217,14 @@ func (c *Config) MarshalJSON() ([]byte, error) {
 func (c *Config) marshalJSON(s JSONMarshalStrategy) ([]byte, error) {
 	switch s {
 	case JSONMarshalPlainText:
-		return json.MarshalIndent(c.plainTextConfig, "", "  ")
+		s := struct {
+			plainTextConfig
+			secureConfig
+		}{
+			c.plainTextConfig,
+			c.secureConfig,
+		}
+		return json.MarshalIndent(s, "", "  ")
 	default:
 		return json.MarshalIndent(c.secureConfig, "", "  ")
 	}


### PR DESCRIPTION
This patch fixes a bug where calls to Config.ToJSON were returning only the private configuration fields, not a complete set of data. ToSecureJSON exists to return only the public information. This patch addresses issue #152.