### PR TITLE
Mock Drivers Refactor

### DIFF
--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	// loads the drivers
+	_ "github.com/emccode/rexray/drivers/mock"
 	_ "github.com/emccode/rexray/drivers/os"
 	_ "github.com/emccode/rexray/drivers/storage"
 	_ "github.com/emccode/rexray/drivers/volume"

--- a/drivers/mock/mock.go
+++ b/drivers/mock/mock.go
@@ -1,0 +1,67 @@
+package mock
+
+import (
+	"os"
+	"strconv"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/emccode/rexray/core"
+)
+
+const (
+	// MockOSDriverName is the name of a mock OS driver used primarily for
+	// testing.
+	MockOSDriverName = "mockOSDriver"
+
+	// MockVolDriverName is the name of a mock volume driver used primarily for
+	// testing.
+	MockVolDriverName = "mockVolumeDriver"
+
+	// MockStorDriverName is the name of a mock storage driver used primarily
+	// for testing.
+	MockStorDriverName = "mockStorageDriver"
+
+	// BadMockOSDriverName is the name of a mock OS driver used primarily for
+	// testing.
+	BadMockOSDriverName = "badMockOSDriver"
+
+	// BadMockVolDriverName is the name of a mock volume driver used primarily
+	// for testing.
+	BadMockVolDriverName = "badMockVolumeDriver"
+
+	// BadMockStorDriverName is the name of a mock storage driver used primarily
+	// for testing.
+	BadMockStorDriverName = "badMockStorageDriver"
+)
+
+func init() {
+	v := os.Getenv("REXRAY_MOCKDRIVERS")
+	log.WithField("REXRAY_MOCKDRIVERS", v).Debug("got REXRAY_MOCKDRIVERS")
+
+	if b, err := strconv.ParseBool(v); !b || err != nil {
+		if err != nil {
+			log.WithError(err).WithField("REXRAY_MOCKDRIVERS", v).Error(
+				"error parsing REXRAY_MOCKDRIVERS")
+		}
+		log.Debug("not registering mock drivers")
+		return
+	}
+
+	RegisterMockDrivers()
+}
+
+// RegisterMockDrivers registers the mock drivers.
+func RegisterMockDrivers() {
+	log.Debug("registering mock drivers")
+	core.RegisterDriver(MockOSDriverName, newOSDriver)
+	core.RegisterDriver(MockVolDriverName, newVolDriver)
+	core.RegisterDriver(MockStorDriverName, newStorDriver)
+}
+
+// RegisterBadMockDrivers registers the bad mock drivers.
+func RegisterBadMockDrivers() {
+	log.Debug("registering bad mock drivers")
+	core.RegisterDriver(BadMockOSDriverName, newBadOSDriver)
+	core.RegisterDriver(BadMockVolDriverName, newBadVolDriver)
+	core.RegisterDriver(BadMockStorDriverName, newBadStorDriver)
+}

--- a/drivers/mock/mock_os_driver.go
+++ b/drivers/mock/mock_os_driver.go
@@ -1,0 +1,56 @@
+package mock
+
+import (
+	"github.com/emccode/rexray/core"
+	"github.com/emccode/rexray/core/errors"
+)
+
+type mockOSDriver struct {
+	name string
+}
+
+type badMockOSDriver struct {
+	mockOSDriver
+}
+
+func newOSDriver() core.Driver {
+	var d core.OSDriver = &mockOSDriver{MockOSDriverName}
+	return d
+}
+
+func newBadOSDriver() core.Driver {
+	var d core.OSDriver = &badMockOSDriver{mockOSDriver{BadMockOSDriverName}}
+	return d
+}
+
+func (m *mockOSDriver) Init(r *core.RexRay) error {
+	return nil
+}
+
+func (m *badMockOSDriver) Init(r *core.RexRay) error {
+	return errors.New("init error")
+}
+
+func (m *mockOSDriver) Name() string {
+	return m.name
+}
+
+func (m *mockOSDriver) GetMounts(string, string) (core.MountInfoArray, error) {
+	return nil, nil
+}
+
+func (m *mockOSDriver) Mounted(string) (bool, error) {
+	return false, nil
+}
+
+func (m *mockOSDriver) Unmount(string) error {
+	return nil
+}
+
+func (m *mockOSDriver) Mount(string, string, string, string) error {
+	return nil
+}
+
+func (m *mockOSDriver) Format(string, string, bool) error {
+	return nil
+}

--- a/drivers/mock/mock_storage_driver.go
+++ b/drivers/mock/mock_storage_driver.go
@@ -1,0 +1,115 @@
+package mock
+
+import (
+	"github.com/emccode/rexray/core"
+	"github.com/emccode/rexray/core/errors"
+)
+
+type mockStorDriver struct {
+	name string
+}
+
+type badMockStorDriver struct {
+	mockStorDriver
+}
+
+func newStorDriver() core.Driver {
+	var d core.StorageDriver = &mockStorDriver{MockStorDriverName}
+	return d
+}
+
+func newBadStorDriver() core.Driver {
+	var d core.StorageDriver = &badMockStorDriver{
+		mockStorDriver{BadMockStorDriverName}}
+	return d
+}
+
+func (m *mockStorDriver) Init(r *core.RexRay) error {
+	return nil
+}
+
+func (m *badMockStorDriver) Init(r *core.RexRay) error {
+	return errors.New("init error")
+}
+
+func (m *mockStorDriver) Name() string {
+	return m.name
+}
+
+func (m *mockStorDriver) GetVolumeMapping() ([]*core.BlockDevice, error) {
+	return []*core.BlockDevice{&core.BlockDevice{
+		DeviceName:   "test",
+		ProviderName: m.name,
+		InstanceID:   "test",
+		Region:       "test",
+	}}, nil
+}
+
+func (m *mockStorDriver) GetInstance() (*core.Instance, error) {
+	return &core.Instance{
+		Name:         "test",
+		InstanceID:   "test",
+		ProviderName: m.name,
+		Region:       "test"}, nil
+}
+
+func (m *mockStorDriver) GetVolume(
+	volumeID, volumeName string) ([]*core.Volume, error) {
+	return []*core.Volume{&core.Volume{
+		Name:             "test",
+		VolumeID:         "test",
+		AvailabilityZone: "test",
+	}}, nil
+}
+
+func (m *mockStorDriver) GetVolumeAttach(
+	volumeID, instanceID string) ([]*core.VolumeAttachment, error) {
+	return nil, nil
+}
+
+func (m *mockStorDriver) CreateSnapshot(
+	runAsync bool,
+	snapshotName, volumeID, description string) ([]*core.Snapshot, error) {
+	return nil, nil
+}
+
+func (m *mockStorDriver) GetSnapshot(
+	volumeID, snapshotID, snapshotName string) ([]*core.Snapshot, error) {
+	return nil, nil
+}
+
+func (m *mockStorDriver) RemoveSnapshot(snapshotID string) error {
+	return nil
+}
+
+func (m *mockStorDriver) CreateVolume(
+	runAsync bool,
+	volumeName, volumeID, snapshotID, volumeType string,
+	IOPS, size int64,
+	availabilityZone string) (*core.Volume, error) {
+	return nil, nil
+}
+
+func (m *mockStorDriver) RemoveVolume(volumeID string) error {
+	return nil
+}
+
+func (m *mockStorDriver) GetDeviceNextAvailable() (string, error) {
+	return "", nil
+}
+
+func (m *mockStorDriver) AttachVolume(
+	runAsync bool, volumeID, instanceID string) ([]*core.VolumeAttachment, error) {
+	return nil, nil
+}
+
+func (m *mockStorDriver) DetachVolume(
+	runAsync bool, volumeID string, instanceID string) error {
+	return nil
+}
+
+func (m *mockStorDriver) CopySnapshot(
+	runAsync bool, volumeID, snapshotID, snapshotName,
+	destinationSnapshotName, destinationRegion string) (*core.Snapshot, error) {
+	return nil, nil
+}

--- a/drivers/mock/mock_volume_driver.go
+++ b/drivers/mock/mock_volume_driver.go
@@ -1,0 +1,74 @@
+package mock
+
+import (
+	"github.com/emccode/rexray/core"
+	"github.com/emccode/rexray/core/errors"
+)
+
+const mockVolDriverName = "mockVolumeDriver"
+
+type mockVolDriver struct {
+	name string
+}
+
+type badMockVolDriver struct {
+	mockVolDriver
+}
+
+func newVolDriver() core.Driver {
+	var d core.VolumeDriver = &mockVolDriver{mockVolDriverName}
+	return d
+}
+
+func newBadVolDriver() core.Driver {
+	var d core.VolumeDriver = &badMockVolDriver{
+		mockVolDriver{BadMockVolDriverName}}
+	return d
+}
+
+func (m *mockVolDriver) Init(r *core.RexRay) error {
+	return nil
+}
+
+func (m *badMockVolDriver) Init(r *core.RexRay) error {
+	return errors.New("init error")
+}
+
+func (m *mockVolDriver) Name() string {
+	return m.name
+}
+
+func (m *mockVolDriver) Mount(
+	volumeName, volumeID string,
+	overwriteFs bool, newFsType string) (string, error) {
+	return "", nil
+}
+
+func (m *mockVolDriver) Unmount(volumeName, volumeID string) error {
+	return nil
+}
+
+func (m *mockVolDriver) Path(volumeName, volumeID string) (string, error) {
+	return "", nil
+}
+
+func (m *mockVolDriver) Create(volumeName string, opts core.VolumeOpts) error {
+	return nil
+}
+
+func (m *mockVolDriver) Remove(volumeName string) error {
+	return nil
+}
+
+func (m *mockVolDriver) Attach(volumeName, instanceID string) (string, error) {
+	return "", nil
+}
+
+func (m *mockVolDriver) Detach(volumeName, instanceID string) error {
+	return nil
+}
+
+func (m *mockVolDriver) NetworkName(
+	volumeName, instanceID string) (string, error) {
+	return "", nil
+}

--- a/test/bad_mock_drivers_test.go
+++ b/test/bad_mock_drivers_test.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/emccode/rexray/core"
 	"github.com/emccode/rexray/core/errors"
+	"github.com/emccode/rexray/drivers/mock"
 )
 
 func TestNewWithBadOSDriver(t *testing.T) {
 	r := core.New(nil)
-	r.Config.OSDrivers = []string{badMockOSDriverName}
-	r.Config.VolumeDrivers = []string{mockVolDriverName}
-	r.Config.StorageDrivers = []string{mockStorDriverName}
+	r.Config.OSDrivers = []string{mock.BadMockOSDriverName}
+	r.Config.VolumeDrivers = []string{mock.MockVolDriverName}
+	r.Config.StorageDrivers = []string{mock.MockStorDriverName}
 	if err := r.InitDrivers(); err != errors.ErrNoOSDrivers {
 		t.Fatal(err)
 	}
@@ -19,9 +20,9 @@ func TestNewWithBadOSDriver(t *testing.T) {
 
 func TestNewWithBadVolumeDriver(t *testing.T) {
 	r := core.New(nil)
-	r.Config.OSDrivers = []string{mockOSDriverName}
-	r.Config.VolumeDrivers = []string{badMockVolDriverName}
-	r.Config.StorageDrivers = []string{mockStorDriverName}
+	r.Config.OSDrivers = []string{mock.MockOSDriverName}
+	r.Config.VolumeDrivers = []string{mock.BadMockVolDriverName}
+	r.Config.StorageDrivers = []string{mock.MockStorDriverName}
 	if err := r.InitDrivers(); err != errors.ErrNoVolumeDrivers {
 		t.Fatal(err)
 	}
@@ -29,52 +30,10 @@ func TestNewWithBadVolumeDriver(t *testing.T) {
 
 func TestNewWithBadStorageDriver(t *testing.T) {
 	r := core.New(nil)
-	r.Config.OSDrivers = []string{mockOSDriverName}
-	r.Config.VolumeDrivers = []string{mockVolDriverName}
-	r.Config.StorageDrivers = []string{badMockStorDriverName}
+	r.Config.OSDrivers = []string{mock.MockOSDriverName}
+	r.Config.VolumeDrivers = []string{mock.MockVolDriverName}
+	r.Config.StorageDrivers = []string{mock.BadMockStorDriverName}
 	if err := r.InitDrivers(); err != errors.ErrNoStorageDrivers {
 		t.Fatal(err)
 	}
-}
-
-type badMockOSDriver struct {
-	mockOSDriver
-}
-
-func newBadOSDriver() core.Driver {
-	var d core.OSDriver = &badMockOSDriver{
-		mockOSDriver{badMockOSDriverName}}
-	return d
-}
-
-func (m *badMockOSDriver) Init(r *core.RexRay) error {
-	return errors.New("init error")
-}
-
-type badMockVolDriver struct {
-	mockVolDriver
-}
-
-func newBadVolDriver() core.Driver {
-	var d core.VolumeDriver = &badMockVolDriver{
-		mockVolDriver{badMockVolDriverName}}
-	return d
-}
-
-func (m *badMockVolDriver) Init(r *core.RexRay) error {
-	return errors.New("init error")
-}
-
-type badMockStorDriver struct {
-	mockStorDriver
-}
-
-func newBadStorDriver() core.Driver {
-	var d core.StorageDriver = &badMockStorDriver{
-		mockStorDriver{badMockStorDriverName}}
-	return d
-}
-
-func (m *badMockStorDriver) Init(r *core.RexRay) error {
-	return errors.New("init error")
 }

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/emccode/rexray/drivers/mock"
 	"github.com/emccode/rexray/rexray/cli"
 )
 
 var defaultFlags = []string{
-	fmt.Sprintf("--osDrivers=%s", mockOSDriverName),
-	fmt.Sprintf("--volumeDrivers=%s", mockVolDriverName),
-	fmt.Sprintf("--storageDrivers=%s", mockStorDriverName),
+	fmt.Sprintf("--osDrivers=%s", mock.MockOSDriverName),
+	fmt.Sprintf("--volumeDrivers=%s", mock.MockVolDriverName),
+	fmt.Sprintf("--storageDrivers=%s", mock.MockStorDriverName),
 }
 
 func a(a ...string) {

--- a/test/os_driver_test.go
+++ b/test/os_driver_test.go
@@ -3,26 +3,9 @@ package test
 import (
 	"testing"
 
-	"github.com/emccode/rexray/core"
 	"github.com/emccode/rexray/core/errors"
+	"github.com/emccode/rexray/drivers/mock"
 )
-
-type mockOSDriver struct {
-	name string
-}
-
-func newOSDriver() core.Driver {
-	var d core.OSDriver = &mockOSDriver{mockOSDriverName}
-	return d
-}
-
-func (m *mockOSDriver) Init(r *core.RexRay) error {
-	return nil
-}
-
-func (m *mockOSDriver) Name() string {
-	return m.name
-}
 
 func TestOSDriverName(t *testing.T) {
 	r, err := getRexRay()
@@ -30,8 +13,8 @@ func TestOSDriverName(t *testing.T) {
 		t.Fatal(err)
 	}
 	d := <-r.OS.Drivers()
-	if d.Name() != mockOSDriverName {
-		t.Fatalf("driver name != %s, == %s", mockOSDriverName, d.Name())
+	if d.Name() != mock.MockOSDriverName {
+		t.Fatalf("driver name != %s, == %s", mock.MockOSDriverName, d.Name())
 	}
 }
 
@@ -40,8 +23,8 @@ func TestOSDriverManagerName(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r.OS.Name() != mockOSDriverName {
-		t.Fatalf("driver name != %s, == %s", mockOSDriverName, r.OS.Name())
+	if r.OS.Name() != mock.MockOSDriverName {
+		t.Fatalf("driver name != %s, == %s", mock.MockOSDriverName, r.OS.Name())
 	}
 }
 
@@ -50,10 +33,6 @@ func TestOSDriverManagerNameNoDrivers(t *testing.T) {
 	if r.OS.Name() != "" {
 		t.Fatal("name not empty")
 	}
-}
-
-func (m *mockOSDriver) GetMounts(string, string) (core.MountInfoArray, error) {
-	return nil, nil
 }
 
 func TestOSDriverGetMounts(t *testing.T) {
@@ -87,10 +66,6 @@ func TestOSDriverManagerGetMountsNoDrivers(t *testing.T) {
 	}
 }
 
-func (m *mockOSDriver) Mounted(string) (bool, error) {
-	return false, nil
-}
-
 func TestOSDriverMounted(t *testing.T) {
 	r, err := getRexRay()
 	if err != nil {
@@ -120,10 +95,6 @@ func TestOSDriverManagerMountedNoDrivers(t *testing.T) {
 	if _, err := r.OS.Mounted(""); err != errors.ErrNoOSDetected {
 		t.Fatal(err)
 	}
-}
-
-func (m *mockOSDriver) Unmount(string) error {
-	return nil
 }
 
 func TestOSDriverUnmount(t *testing.T) {
@@ -157,10 +128,6 @@ func TestOSDriverManagerUnmountNoDrivers(t *testing.T) {
 	}
 }
 
-func (m *mockOSDriver) Mount(string, string, string, string) error {
-	return nil
-}
-
 func TestOSDriverMount(t *testing.T) {
 	r, err := getRexRay()
 	if err != nil {
@@ -190,10 +157,6 @@ func TestOSDriverManagerMountNoDrivers(t *testing.T) {
 	if err := r.OS.Mount("", "", "", ""); err != errors.ErrNoOSDetected {
 		t.Fatal(err)
 	}
-}
-
-func (m *mockOSDriver) Format(string, string, bool) error {
-	return nil
 }
 
 func TestOSDriverFormat(t *testing.T) {

--- a/test/storage_driver_test.go
+++ b/test/storage_driver_test.go
@@ -3,26 +3,9 @@ package test
 import (
 	"testing"
 
-	"github.com/emccode/rexray/core"
 	"github.com/emccode/rexray/core/errors"
+	"github.com/emccode/rexray/drivers/mock"
 )
-
-type mockStorDriver struct {
-	name string
-}
-
-func newStorDriver() core.Driver {
-	var d core.StorageDriver = &mockStorDriver{mockStorDriverName}
-	return d
-}
-
-func (m *mockStorDriver) Init(r *core.RexRay) error {
-	return nil
-}
-
-func (m *mockStorDriver) Name() string {
-	return m.name
-}
 
 func TestStorageDriverName(t *testing.T) {
 	r, err := getRexRay()
@@ -30,8 +13,8 @@ func TestStorageDriverName(t *testing.T) {
 		t.Fatal(err)
 	}
 	d := <-r.Storage.Drivers()
-	if d.Name() != mockStorDriverName {
-		t.Fatalf("driver name != %s, == %s", mockStorDriverName, d.Name())
+	if d.Name() != mock.MockStorDriverName {
+		t.Fatalf("driver name != %s, == %s", mock.MockStorDriverName, d.Name())
 	}
 }
 
@@ -40,8 +23,8 @@ func TestStorageDriverManagerName(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r.Storage.Name() != mockStorDriverName {
-		t.Fatalf("driver name != %s, == %s", mockStorDriverName, r.Storage.Name())
+	if r.Storage.Name() != mock.MockStorDriverName {
+		t.Fatalf("driver name != %s, == %s", mock.MockStorDriverName, r.Storage.Name())
 	}
 }
 
@@ -50,15 +33,6 @@ func TestStorageDriverManagerNameNoDrivers(t *testing.T) {
 	if r.Storage.Name() != "" {
 		t.Fatal("name not empty")
 	}
-}
-
-func (m *mockStorDriver) GetVolumeMapping() ([]*core.BlockDevice, error) {
-	return []*core.BlockDevice{&core.BlockDevice{
-		DeviceName:   "test",
-		ProviderName: mockStorDriverName,
-		InstanceID:   "test",
-		Region:       "test",
-	}}, nil
 }
 
 func TestStorageDriverGetVolumeMapping(t *testing.T) {
@@ -90,14 +64,6 @@ func TestStorageDriverManagerGetVolumeMappingNoDrivers(t *testing.T) {
 	if _, err := r.Storage.GetVolumeMapping(); err != errors.ErrNoStorageDetected {
 		t.Fatal(err)
 	}
-}
-
-func (m *mockStorDriver) GetInstance() (*core.Instance, error) {
-	return &core.Instance{
-		Name:         "test",
-		InstanceID:   "test",
-		ProviderName: mockStorDriverName,
-		Region:       "test"}, nil
 }
 
 func TestStorageDriverGetInstance(t *testing.T) {
@@ -151,15 +117,6 @@ func TestGetInstancesNoDrivers(t *testing.T) {
 	}
 }
 
-func (m *mockStorDriver) GetVolume(
-	volumeID, volumeName string) ([]*core.Volume, error) {
-	return []*core.Volume{&core.Volume{
-		Name:             "test",
-		VolumeID:         "test",
-		AvailabilityZone: "test",
-	}}, nil
-}
-
 func TestStorageDriverGetVolume(t *testing.T) {
 	r, err := getRexRay()
 	if err != nil {
@@ -192,11 +149,6 @@ func TestStorageDriverManagerGetVolumeNoDrivers(t *testing.T) {
 		"", ""); err != errors.ErrNoStorageDetected {
 		t.Fatal(err)
 	}
-}
-
-func (m *mockStorDriver) GetVolumeAttach(
-	volumeID, instanceID string) ([]*core.VolumeAttachment, error) {
-	return nil, nil
 }
 
 func TestStorageDriverGetVolumeAttach(t *testing.T) {
@@ -233,12 +185,6 @@ func TestStorageDriverManagerGetVolumeAttachNoDrivers(t *testing.T) {
 	}
 }
 
-func (m *mockStorDriver) CreateSnapshot(
-	runAsync bool,
-	snapshotName, volumeID, description string) ([]*core.Snapshot, error) {
-	return nil, nil
-}
-
 func TestStorageDriverCreateSnapshot(t *testing.T) {
 	r, err := getRexRay()
 	if err != nil {
@@ -271,11 +217,6 @@ func TestStorageDriverManagerCreateSnapshotNoDrivers(t *testing.T) {
 		false, "", "", ""); err != errors.ErrNoStorageDetected {
 		t.Fatal(err)
 	}
-}
-
-func (m *mockStorDriver) GetSnapshot(
-	volumeID, snapshotID, snapshotName string) ([]*core.Snapshot, error) {
-	return nil, nil
 }
 
 func TestStorageDriverGetSnapshot(t *testing.T) {
@@ -312,10 +253,6 @@ func TestStorageDriverManagerGetSnapshotNoDrivers(t *testing.T) {
 	}
 }
 
-func (m *mockStorDriver) RemoveSnapshot(snapshotID string) error {
-	return nil
-}
-
 func TestStorageDriverRemoveSnapshot(t *testing.T) {
 	r, err := getRexRay()
 	if err != nil {
@@ -345,14 +282,6 @@ func TestStorageDriverManagerRemoveSnapshotNoDrivers(t *testing.T) {
 	if err := r.Storage.RemoveSnapshot(""); err != errors.ErrNoStorageDetected {
 		t.Fatal(err)
 	}
-}
-
-func (m *mockStorDriver) CreateVolume(
-	runAsync bool,
-	volumeName, volumeID, snapshotID, volumeType string,
-	IOPS, size int64,
-	availabilityZone string) (*core.Volume, error) {
-	return nil, nil
 }
 
 func TestStorageDriverCreateVolume(t *testing.T) {
@@ -389,10 +318,6 @@ func TestStorageDriverManagerCreateVolumeNoDrivers(t *testing.T) {
 	}
 }
 
-func (m *mockStorDriver) RemoveVolume(volumeID string) error {
-	return nil
-}
-
 func TestStorageDriverRemoveVolume(t *testing.T) {
 	r, err := getRexRay()
 	if err != nil {
@@ -424,10 +349,6 @@ func TestStorageDriverManagerRemoveVolumeNoDrivers(t *testing.T) {
 	}
 }
 
-func (m *mockStorDriver) GetDeviceNextAvailable() (string, error) {
-	return "", nil
-}
-
 func TestStorageDriverGetDeviceNextAvailable(t *testing.T) {
 	r, err := getRexRay()
 	if err != nil {
@@ -457,11 +378,6 @@ func TestStorageDriverManagerGetDeviceNextAvailableNoDrivers(t *testing.T) {
 	if _, err := r.Storage.GetDeviceNextAvailable(); err != errors.ErrNoStorageDetected {
 		t.Fatal(err)
 	}
-}
-
-func (m *mockStorDriver) AttachVolume(
-	runAsync bool, volumeID, instanceID string) ([]*core.VolumeAttachment, error) {
-	return nil, nil
 }
 
 func TestStorageDriverAttachVolume(t *testing.T) {
@@ -498,11 +414,6 @@ func TestStorageDriverManagerAttachVolumeNoDrivers(t *testing.T) {
 	}
 }
 
-func (m *mockStorDriver) DetachVolume(
-	runAsync bool, volumeID string, instanceID string) error {
-	return nil
-}
-
 func TestStorageDriverDetachVolume(t *testing.T) {
 	r, err := getRexRay()
 	if err != nil {
@@ -535,12 +446,6 @@ func TestStorageDriverManagerDetachVolumeNoDrivers(t *testing.T) {
 		false, "", ""); err != errors.ErrNoStorageDetected {
 		t.Fatal(err)
 	}
-}
-
-func (m *mockStorDriver) CopySnapshot(
-	runAsync bool, volumeID, snapshotID, snapshotName,
-	destinationSnapshotName, destinationRegion string) (*core.Snapshot, error) {
-	return nil, nil
 }
 
 func TestStorageDriverCopySnapshot(t *testing.T) {

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -11,42 +11,21 @@ import (
 	"github.com/emccode/rexray/core"
 	"github.com/emccode/rexray/core/config"
 	"github.com/emccode/rexray/core/errors"
+	"github.com/emccode/rexray/drivers/mock"
 	"github.com/emccode/rexray/util"
 )
 
-const (
-	mockOSDriverName   = "mockOSDriver"
-	mockVolDriverName  = "mockVolumeDriver"
-	mockStorDriverName = "mockStorageDriver"
-
-	badMockOSDriverName   = "badMockOSDriver"
-	badMockVolDriverName  = "badMockVolumeDriver"
-	badMockStorDriverName = "badMockStorageDriver"
-)
-
-func registerMockDrivers() {
-	core.RegisterDriver(mockOSDriverName, newOSDriver)
-	core.RegisterDriver(mockVolDriverName, newVolDriver)
-	core.RegisterDriver(mockStorDriverName, newStorDriver)
-}
-
-func registerBadMockDrivers() {
-	core.RegisterDriver(badMockOSDriverName, newBadOSDriver)
-	core.RegisterDriver(badMockVolDriverName, newBadVolDriver)
-	core.RegisterDriver(badMockStorDriverName, newBadStorDriver)
-}
-
 func TestMain(m *testing.M) {
-	registerMockDrivers()
-	registerBadMockDrivers()
+	mock.RegisterMockDrivers()
+	mock.RegisterBadMockDrivers()
 	os.Exit(m.Run())
 }
 
 func getRexRay() (*core.RexRay, error) {
 	c := config.New()
-	c.OSDrivers = []string{mockOSDriverName}
-	c.VolumeDrivers = []string{mockVolDriverName}
-	c.StorageDrivers = []string{mockStorDriverName}
+	c.OSDrivers = []string{mock.MockOSDriverName}
+	c.VolumeDrivers = []string{mock.MockVolDriverName}
+	c.StorageDrivers = []string{mock.MockStorDriverName}
 	r := core.New(c)
 
 	if err := r.InitDrivers(); err != nil {
@@ -77,9 +56,9 @@ func TestNewWithConfig(t *testing.T) {
 
 func TestNewWithNilConfig(t *testing.T) {
 	r := core.New(nil)
-	r.Config.OSDrivers = []string{mockOSDriverName}
-	r.Config.VolumeDrivers = []string{mockVolDriverName}
-	r.Config.StorageDrivers = []string{mockStorDriverName}
+	r.Config.OSDrivers = []string{mock.MockOSDriverName}
+	r.Config.VolumeDrivers = []string{mock.MockVolDriverName}
+	r.Config.StorageDrivers = []string{mock.MockStorDriverName}
 
 	if err := r.InitDrivers(); err != nil {
 		t.Fatal(err)
@@ -89,9 +68,9 @@ func TestNewWithNilConfig(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
-	os.Setenv("REXRAY_OSDRIVERS", mockOSDriverName)
-	os.Setenv("REXRAY_VOLUMEDRIVERS", mockVolDriverName)
-	os.Setenv("REXRAY_STORAGEDRIVERS", mockStorDriverName)
+	os.Setenv("REXRAY_OSDRIVERS", mock.MockOSDriverName)
+	os.Setenv("REXRAY_VOLUMEDRIVERS", mock.MockVolDriverName)
+	os.Setenv("REXRAY_STORAGEDRIVERS", mock.MockStorDriverName)
 
 	r, err := rexray.New()
 	if err != nil {
@@ -108,8 +87,8 @@ func TestNew(t *testing.T) {
 func TestNewNoOSDrivers(t *testing.T) {
 	c := config.New()
 	c.OSDrivers = []string{}
-	c.VolumeDrivers = []string{mockVolDriverName}
-	c.StorageDrivers = []string{mockStorDriverName}
+	c.VolumeDrivers = []string{mock.MockVolDriverName}
+	c.StorageDrivers = []string{mock.MockStorDriverName}
 	r := core.New(c)
 	if err := r.InitDrivers(); err != errors.ErrNoOSDrivers {
 		t.Fatal(err)
@@ -118,9 +97,9 @@ func TestNewNoOSDrivers(t *testing.T) {
 
 func TestNewNoVolumeDrivers(t *testing.T) {
 	c := config.New()
-	c.OSDrivers = []string{mockOSDriverName}
+	c.OSDrivers = []string{mock.MockOSDriverName}
 	c.VolumeDrivers = []string{}
-	c.StorageDrivers = []string{mockStorDriverName}
+	c.StorageDrivers = []string{mock.MockStorDriverName}
 	r := core.New(c)
 	if err := r.InitDrivers(); err != errors.ErrNoVolumeDrivers {
 		t.Fatal(err)
@@ -129,8 +108,8 @@ func TestNewNoVolumeDrivers(t *testing.T) {
 
 func TestNewNoStorageDrivers(t *testing.T) {
 	c := config.New()
-	c.OSDrivers = []string{mockOSDriverName}
-	c.VolumeDrivers = []string{mockVolDriverName}
+	c.OSDrivers = []string{mock.MockOSDriverName}
+	c.VolumeDrivers = []string{mock.MockVolDriverName}
 	c.StorageDrivers = []string{}
 	r := core.New(c)
 	if err := r.InitDrivers(); err != errors.ErrNoStorageDrivers {
@@ -140,9 +119,9 @@ func TestNewNoStorageDrivers(t *testing.T) {
 
 func TestNewWithEnv(t *testing.T) {
 	r, err := rexray.NewWithEnv(map[string]string{
-		"REXRAY_OSDRIVERS":      mockOSDriverName,
-		"REXRAY_VOLUMEDRIVERS":  mockVolDriverName,
-		"REXRAY_STORAGEDRIVERS": mockStorDriverName,
+		"REXRAY_OSDRIVERS":      mock.MockOSDriverName,
+		"REXRAY_VOLUMEDRIVERS":  mock.MockVolDriverName,
+		"REXRAY_STORAGEDRIVERS": mock.MockStorDriverName,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -206,12 +185,12 @@ func TestNewWithBadConfigReader(t *testing.T) {
 
 func TestDriverNames(t *testing.T) {
 	allDriverNames := []string{
-		strings.ToLower(mockOSDriverName),
-		strings.ToLower(mockVolDriverName),
-		strings.ToLower(mockStorDriverName),
-		strings.ToLower(badMockOSDriverName),
-		strings.ToLower(badMockVolDriverName),
-		strings.ToLower(badMockStorDriverName),
+		strings.ToLower(mock.MockOSDriverName),
+		strings.ToLower(mock.MockVolDriverName),
+		strings.ToLower(mock.MockStorDriverName),
+		strings.ToLower(mock.BadMockOSDriverName),
+		strings.ToLower(mock.BadMockVolDriverName),
+		strings.ToLower(mock.BadMockStorDriverName),
 		"linux",
 		"docker",
 		"ec2",
@@ -248,12 +227,12 @@ func TestRexRayDriverNames(t *testing.T) {
 	}
 
 	allDriverNames := []string{
-		strings.ToLower(mockOSDriverName),
-		strings.ToLower(mockVolDriverName),
-		strings.ToLower(mockStorDriverName),
-		strings.ToLower(badMockOSDriverName),
-		strings.ToLower(badMockVolDriverName),
-		strings.ToLower(badMockStorDriverName),
+		strings.ToLower(mock.MockOSDriverName),
+		strings.ToLower(mock.MockVolDriverName),
+		strings.ToLower(mock.MockStorDriverName),
+		strings.ToLower(mock.BadMockOSDriverName),
+		strings.ToLower(mock.BadMockVolDriverName),
+		strings.ToLower(mock.BadMockStorDriverName),
 		"linux",
 		"docker",
 		"ec2",
@@ -283,18 +262,18 @@ func TestRexRayDriverNames(t *testing.T) {
 
 func assertDriverNames(t *testing.T, r *core.RexRay) {
 	od := <-r.OS.Drivers()
-	if od.Name() != mockOSDriverName {
-		t.Fatalf("expected %s but was %s", mockOSDriverName, od.Name())
+	if od.Name() != mock.MockOSDriverName {
+		t.Fatalf("expected %s but was %s", mock.MockOSDriverName, od.Name())
 	}
 
 	vd := <-r.Volume.Drivers()
-	if vd.Name() != mockVolDriverName {
-		t.Fatalf("expected %s but was %s", mockVolDriverName, vd.Name())
+	if vd.Name() != mock.MockVolDriverName {
+		t.Fatalf("expected %s but was %s", mock.MockVolDriverName, vd.Name())
 	}
 
 	sd := <-r.Storage.Drivers()
-	if sd.Name() != mockStorDriverName {
-		t.Fatalf("expected %s but was %s", mockStorDriverName, sd.Name())
+	if sd.Name() != mock.MockStorDriverName {
+		t.Fatalf("expected %s but was %s", mock.MockStorDriverName, sd.Name())
 	}
 }
 

--- a/test/volume_driver_test.go
+++ b/test/volume_driver_test.go
@@ -3,26 +3,9 @@ package test
 import (
 	"testing"
 
-	"github.com/emccode/rexray/core"
 	"github.com/emccode/rexray/core/errors"
+	"github.com/emccode/rexray/drivers/mock"
 )
-
-type mockVolDriver struct {
-	name string
-}
-
-func newVolDriver() core.Driver {
-	var d core.VolumeDriver = &mockVolDriver{mockVolDriverName}
-	return d
-}
-
-func (m *mockVolDriver) Init(r *core.RexRay) error {
-	return nil
-}
-
-func (m *mockVolDriver) Name() string {
-	return m.name
-}
 
 func TestVolumeDriverName(t *testing.T) {
 	r, err := getRexRay()
@@ -30,8 +13,8 @@ func TestVolumeDriverName(t *testing.T) {
 		t.Fatal(err)
 	}
 	d := <-r.Volume.Drivers()
-	if d.Name() != mockVolDriverName {
-		t.Fatalf("driver name != %s, == %s", mockVolDriverName, d.Name())
+	if d.Name() != mock.MockVolDriverName {
+		t.Fatalf("driver name != %s, == %s", mock.MockVolDriverName, d.Name())
 	}
 }
 
@@ -40,8 +23,8 @@ func TestVolumeDriverManagerName(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r.Volume.Name() != mockVolDriverName {
-		t.Fatalf("driver name != %s, == %s", mockVolDriverName, r.Volume.Name())
+	if r.Volume.Name() != mock.MockVolDriverName {
+		t.Fatalf("driver name != %s, == %s", mock.MockVolDriverName, r.Volume.Name())
 	}
 }
 
@@ -112,12 +95,6 @@ func TestDetachAllNoDrivers(t *testing.T) {
 	}
 }
 
-func (m *mockVolDriver) Mount(
-	volumeName, volumeID string,
-	overwriteFs bool, newFsType string) (string, error) {
-	return "", nil
-}
-
 func TestVolumeDriverMount(t *testing.T) {
 	r, err := getRexRay()
 	if err != nil {
@@ -147,10 +124,6 @@ func TestVolumeDriverManagerMountNoDrivers(t *testing.T) {
 	if _, err := r.Volume.Mount("", "", false, ""); err != errors.ErrNoVolumesDetected {
 		t.Fatal(err)
 	}
-}
-
-func (m *mockVolDriver) Unmount(volumeName, volumeID string) error {
-	return nil
 }
 
 func TestVolumeDriverUnmount(t *testing.T) {
@@ -184,10 +157,6 @@ func TestVolumeDriverManagerUnmountNoDrivers(t *testing.T) {
 	}
 }
 
-func (m *mockVolDriver) Path(volumeName, volumeID string) (string, error) {
-	return "", nil
-}
-
 func TestVolumeDriverPath(t *testing.T) {
 	r, err := getRexRay()
 	if err != nil {
@@ -217,10 +186,6 @@ func TestVolumeDriverManagerPathNoDrivers(t *testing.T) {
 	if _, err := r.Volume.Path("", ""); err != errors.ErrNoVolumesDetected {
 		t.Fatal(err)
 	}
-}
-
-func (m *mockVolDriver) Create(volumeName string, opts core.VolumeOpts) error {
-	return nil
 }
 
 func TestVolumeDriverCreate(t *testing.T) {
@@ -254,10 +219,6 @@ func TestVolumeDriverManagerCreateNoDrivers(t *testing.T) {
 	}
 }
 
-func (m *mockVolDriver) Remove(volumeName string) error {
-	return nil
-}
-
 func TestVolumeDriverRemove(t *testing.T) {
 	r, err := getRexRay()
 	if err != nil {
@@ -287,10 +248,6 @@ func TestVolumeDriverManagerRemoveNoDrivers(t *testing.T) {
 	if err := r.Volume.Remove(""); err != errors.ErrNoVolumesDetected {
 		t.Fatal(err)
 	}
-}
-
-func (m *mockVolDriver) Attach(volumeName, instanceID string) (string, error) {
-	return "", nil
 }
 
 func TestVolumeDriverAttach(t *testing.T) {
@@ -324,10 +281,6 @@ func TestVolumeDriverManagerAttachNoDrivers(t *testing.T) {
 	}
 }
 
-func (m *mockVolDriver) Detach(volumeName, instanceID string) error {
-	return nil
-}
-
 func TestVolumeDriverDetach(t *testing.T) {
 	r, err := getRexRay()
 	if err != nil {
@@ -357,11 +310,6 @@ func TestVolumeDriverManagerDetachNoDrivers(t *testing.T) {
 	if err := r.Volume.Detach("", ""); err != errors.ErrNoVolumesDetected {
 		t.Fatal(err)
 	}
-}
-
-func (m *mockVolDriver) NetworkName(
-	volumeName, instanceID string) (string, error) {
-	return "", nil
 }
 
 func TestVolumeDriverNetworkName(t *testing.T) {


### PR DESCRIPTION
This path refactors the mock (and bad mock) drivers formerly in the `github.com/emccode/rexray/test` package into the `github.com/emccode/rexray/drivers/mock` package. This is to support mock drivers during normal operations and not just automated tests.

The mock drivers are not automatically registered. To elect to use the mock drivers an environment variable of `REXRAY_MOCKDRIVERS` must be set to a value that evaluates to boolean true.

At this point it is possible to use `mockOSDriver`, `mockVolumeDriver`, and `mockStorageDriver` as values for the environment variables, config options, and CLI flags that control which drivers should be initialized. For example:

```
[0]akutz@pax:rexray$ env REXRAY_MOCKDRIVERS=true rexray volume --osDrivers=mockOSDriver --volumeDrivers=mockVolumeDriver --storageDrivers=mockStorageDriver
- name: test
  volumeid: test
  availabilityzone: test
  status: ""
  volumetype: ""
  iops: 0
  size: ""
  networkname: ""
  attachments: []
```