### PR TITLE
Fixed typo in the CLI snapshot copy command

### DIFF
--- a/rexray/cli/cmds_snapshot.go
+++ b/rexray/cli/cmds_snapshot.go
@@ -97,7 +97,7 @@ func (c *CLI) initSnapshotCmds() {
 
 	c.snapshotCopyCmd = &cobra.Command{
 		Use:   "copy",
-		Short: "Copie a snapshot",
+		Short: "Copies a snapshot",
 		Run: func(cmd *cobra.Command, args []string) {
 
 			if c.snapshotID == "" && c.volumeID == "" && c.volumeName == "" {


### PR DESCRIPTION
This patch fixes a typo in the `snapshot copy` command. The description used to read `Copie a snapshot`, and this patch fixes it so it now reads `Copies a snapshot`. 

This PR is being submitted on behalf of @kacole2 as he's the one who fixed the issue and authored the PR's commit. Thanks Kenny!