### PR TITLE
Uninstallation no longer removes data dirs

### DIFF
--- a/rexray/cli/installer.go
+++ b/rexray/cli/installer.go
@@ -142,11 +142,6 @@ func uninstall(pkgManager bool) {
 		uninstallChkConfig()
 	}
 
-	os.RemoveAll(util.EtcDirPath())
-	os.RemoveAll(util.RunDirPath())
-	os.RemoveAll(util.LibDirPath())
-	os.RemoveAll(util.LogDirPath())
-
 	if !pkgManager {
 		os.Remove(binFile)
 		if util.IsPrefixed() {


### PR DESCRIPTION
This patch addresses issue #126 and updates the uninstallation process so that the REX-Ray data directories such as `/etc/rexray` or `/var/log/rexray` are no longer removed when the program is uninstalled.