### PR TITLE
Fix for mock drivers error message

### DIFF
--- a/drivers/mock/mock.go
+++ b/drivers/mock/mock.go
@@ -39,10 +39,6 @@ func init() {
 	log.WithField("REXRAY_MOCKDRIVERS", v).Debug("got REXRAY_MOCKDRIVERS")
 
 	if b, err := strconv.ParseBool(v); !b || err != nil {
-		if err != nil {
-			log.WithError(err).WithField("REXRAY_MOCKDRIVERS", v).Error(
-				"error parsing REXRAY_MOCKDRIVERS")
-		}
 		log.Debug("not registering mock drivers")
 		return
 	}


### PR DESCRIPTION
This patch removes the unnecessary message logged as an error when the `REXRAY_MOCKDRIVERS` environment variable cannot be parsed. This is related to issue #163. Many thanks to @drumulonimbus for catching this!