### PR TITLE
Fix for a typo in service.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ export REXRAY_STORAGEDRIVERS=ec2
 $ export AWS_ACCESS_KEY=access_key
 $ export AWS_SECRET_KEY=secret_key
 $ rexray service start
-Starting REX-Ray...SUCESS!
+Starting REX-Ray...SUCCESS!
 
   The REX-Ray daemon is now running at PID XX. To
   shutdown the daemon execute the following command:

--- a/rexray/cli/service.go
+++ b/rexray/cli/service.go
@@ -192,7 +192,7 @@ func (c *CLI) tryToStartDaemon() {
 	}
 
 	pid, _ := util.ReadPidFile()
-	fmt.Printf("SUCESS!\n\n")
+	fmt.Printf("SUCCESS!\n\n")
 	fmt.Printf("  The REX-Ray daemon is now running at PID %d. To\n", pid)
 	fmt.Printf("  shutdown the daemon execute the following command:\n\n")
 	fmt.Printf("    sudo %s stop\n\n", thisAbsPath)


### PR DESCRIPTION
After starting the REX-Ray service it outputs "SUCESS",
this commit fixes that and also updates README
to reflect the changes.

Signed-off-by: <jonas.rosland@gmail.com>