### PR TITLE
Fix for build issue due to Viper API change

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -199,7 +199,7 @@ func (c *Config) ReadConfig(in io.Reader) error {
 		return errors.New("config reader is nil")
 	}
 
-	c.v.ReadConfigNoNil(in)
+	c.v.MergeConfig(in)
 
 	return nil
 }


### PR DESCRIPTION
This patch fixes the build error due to the Viper API changing from ReadConfigNoNil to MergeConfig.