### PR TITLE
Added pre-emption capabilities to drivers

### DIFF
--- a/.docs/user-guide/config.md
+++ b/.docs/user-guide/config.md
@@ -256,3 +256,33 @@ supported:
 Docker   | docker
 
 The volume driver `docker` is automatically activated.
+
+### Pre-emptive Volume Mount
+There is a capability to pre-emptively detach any existing attachments to other
+instances before attempting a mount.  This will enable use cases for
+availability where another instance must be able to take control of a volume
+without the current owner instance being involved.  The operation is considered
+equivalent to a power off of the existing instance for the device.
+
+Example configuration file follows:
+```yaml
+rexray:
+  storageDrivers:
+  - openstack
+  volume:
+    mountPreempt: true
+openStack:
+  authUrl: https://authUrl:35357/v2.0/
+  username: username
+  password: password
+  tenantName: tenantName
+  regionName: regionName
+```
+
+Driver|Supported
+------|---------
+EC2|Yes
+OpenStack|With Cinder v2
+ScaleIO|Yes
+Rackspace|No
+XtremIO|Yes

--- a/.docs/user-guide/config.md
+++ b/.docs/user-guide/config.md
@@ -270,7 +270,8 @@ rexray:
   storageDrivers:
   - openstack
   volume:
-    mountPreempt: true
+    mount:
+      preempt: true
 openStack:
   authUrl: https://authUrl:35357/v2.0/
   username: username

--- a/core/drivers_storage.go
+++ b/core/drivers_storage.go
@@ -176,11 +176,11 @@ type StorageDriver interface {
 	// AttachVolume returns a list of VolumeAttachments is sync/async that will
 	// attach a volume to an instance based on volumeID and instanceID.
 	AttachVolume(
-		runAsync bool, volumeID, instanceID string) ([]*VolumeAttachment, error)
+		runAsync bool, volumeID, instanceID string, force bool) ([]*VolumeAttachment, error)
 
 	// DetachVolume is sync/async that will detach the volumeID from the local
 	// instance or the instanceID.
-	DetachVolume(runAsync bool, volumeID string, instanceID string) error
+	DetachVolume(runAsync bool, volumeID string, instanceID string, force bool) error
 
 	// CopySnapshot is a sync/async and returns a snapshot that will copy a
 	// snapshot based on volumeID/snapshotID/snapshotName and create a new
@@ -370,18 +370,18 @@ func (r *sdm) RemoveVolume(volumeID string) error {
 
 func (r *sdm) AttachVolume(
 	runAsync bool,
-	volumeID, instanceID string) ([]*VolumeAttachment, error) {
+	volumeID, instanceID string, force bool) ([]*VolumeAttachment, error) {
 	for _, d := range r.drivers {
-		return d.AttachVolume(runAsync, volumeID, instanceID)
+		return d.AttachVolume(runAsync, volumeID, instanceID, force)
 	}
 	return nil, errors.ErrNoStorageDetected
 }
 
 func (r *sdm) DetachVolume(
 	runAsync bool,
-	volumeID, instanceID string) error {
+	volumeID, instanceID string, force bool) error {
 	for _, d := range r.drivers {
-		return d.DetachVolume(runAsync, volumeID, instanceID)
+		return d.DetachVolume(runAsync, volumeID, instanceID, force)
 	}
 	return errors.ErrNoStorageDetected
 }

--- a/core/drivers_volume.go
+++ b/core/drivers_volume.go
@@ -136,7 +136,7 @@ func (r *vdm) Mount(
 	overwriteFs bool, newFsType string, preempt bool) (string, error) {
 	for _, d := range r.drivers {
 		if !preempt {
-			preempt = r.rexray.Config.GetBool("rexray.volume.mountPreempt")
+			preempt = r.rexray.Config.GetBool("rexray.volume.mount.preempt")
 		}
 
 		return d.Mount(volumeName, volumeID, overwriteFs, newFsType, preempt)

--- a/daemon/module/docker/remotevolumedriver/remvoldriver.go
+++ b/daemon/module/docker/remotevolumedriver/remvoldriver.go
@@ -269,7 +269,7 @@ func (m *mod) buildMux() *http.ServeMux {
 			return
 		}
 
-		networkName, err := m.r.Volume.Attach(pr.Name, pr.InstanceID)
+		networkName, err := m.r.Volume.Attach(pr.Name, pr.InstanceID, false)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("{\"Error\":\"%s\"}", err.Error()), 500)
 			return
@@ -291,7 +291,7 @@ func (m *mod) buildMux() *http.ServeMux {
 			return
 		}
 
-		err := m.r.Volume.Detach(pr.Name, pr.InstanceID)
+		err := m.r.Volume.Detach(pr.Name, pr.InstanceID, false)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("{\"Error\":\"%s\"}", err.Error()), 500)
 			return

--- a/daemon/module/docker/volumedriver/voldriver.go
+++ b/daemon/module/docker/volumedriver/voldriver.go
@@ -257,7 +257,7 @@ func (m *mod) buildMux() *http.ServeMux {
 			return
 		}
 
-		mountPath, err := m.r.Volume.Mount(pr.Name, "", false, "")
+		mountPath, err := m.r.Volume.Mount(pr.Name, "", false, "", false)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("{\"Error\":\"%s\"}", err.Error()), 500)
 			log.WithField("error", err).Error("/VolumeDriver.Mount: error mounting volume")

--- a/drivers/mock/mock_storage_driver.go
+++ b/drivers/mock/mock_storage_driver.go
@@ -100,12 +100,12 @@ func (m *mockStorDriver) GetDeviceNextAvailable() (string, error) {
 }
 
 func (m *mockStorDriver) AttachVolume(
-	runAsync bool, volumeID, instanceID string) ([]*core.VolumeAttachment, error) {
+	runAsync bool, volumeID, instanceID string, force bool) ([]*core.VolumeAttachment, error) {
 	return nil, nil
 }
 
 func (m *mockStorDriver) DetachVolume(
-	runAsync bool, volumeID string, instanceID string) error {
+	runAsync bool, volumeID string, instanceID string, force bool) error {
 	return nil
 }
 

--- a/drivers/mock/mock_volume_driver.go
+++ b/drivers/mock/mock_volume_driver.go
@@ -41,7 +41,7 @@ func (m *mockVolDriver) Name() string {
 
 func (m *mockVolDriver) Mount(
 	volumeName, volumeID string,
-	overwriteFs bool, newFsType string) (string, error) {
+	overwriteFs bool, newFsType string, preempt bool) (string, error) {
 	return "", nil
 }
 
@@ -61,11 +61,11 @@ func (m *mockVolDriver) Remove(volumeName string) error {
 	return nil
 }
 
-func (m *mockVolDriver) Attach(volumeName, instanceID string) (string, error) {
+func (m *mockVolDriver) Attach(volumeName, instanceID string, force bool) (string, error) {
 	return "", nil
 }
 
-func (m *mockVolDriver) Detach(volumeName, instanceID string) error {
+func (m *mockVolDriver) Detach(volumeName, instanceID string, force bool) error {
 	return nil
 }
 

--- a/drivers/storage/rackspace/rackspace.go
+++ b/drivers/storage/rackspace/rackspace.go
@@ -774,7 +774,7 @@ func getLocalDevices() (deviceNames []string, err error) {
 }
 
 func (d *driver) AttachVolume(
-	runAsync bool, volumeID, instanceID string) ([]*core.VolumeAttachment, error) {
+	runAsync bool, volumeID, instanceID string, force bool) ([]*core.VolumeAttachment, error) {
 
 	fields := eff(map[string]interface{}{
 		"runAsync":   runAsync,
@@ -818,7 +818,7 @@ func (d *driver) AttachVolume(
 }
 
 func (d *driver) DetachVolume(
-	runAsync bool, volumeID, instanceID string) error {
+	runAsync bool, volumeID, instanceID string, force bool) error {
 
 	fields := eff(map[string]interface{}{
 		"runAsync":   runAsync,

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -2,5 +2,16 @@ package volume
 
 import (
 	// loads the volume drivers
+	"github.com/akutz/gofig"
 	_ "github.com/emccode/rexray/drivers/volume/docker"
 )
+
+func init() {
+	gofig.Register(configRegistration())
+}
+
+func configRegistration() *gofig.Registration {
+	r := gofig.NewRegistration("Volume")
+	r.Key(gofig.Bool, "", false, "", "rexray.volume.mountPreempt")
+	return r
+}

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -12,6 +12,6 @@ func init() {
 
 func configRegistration() *gofig.Registration {
 	r := gofig.NewRegistration("Volume")
-	r.Key(gofig.Bool, "", false, "", "rexray.volume.mountPreempt")
+	r.Key(gofig.Bool, "", false, "", "rexray.volume.mount.preempt", "preempt")
 	return r
 }

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,7 +13,7 @@ import:
     repo:    https://github.com/akutz/viper.git
     vcs:     git
   - package: github.com/goamz/goamz
-    ref:     d864e94f00efde9785b51e0d9f9e3ed04e2e6ecd
+    ref:     5c85623a00092be41b679e53ef47772cf8ded1da
     repo:    https://github.com/clintonskitson/goamz
     vcs:     git
   - package: github.com/emccode/goscaleio
@@ -47,4 +47,8 @@ import:
   - package: gopkg.in/yaml.v2
     ref:     b4a9f8c4b84c6c4256d669c649837f1441e4b050
     repo:    https://github.com/akutz/yaml.git
+    vcs:     git
+  - package: github.com/rackspace/gophercloud
+    ref:     30f929fcb1c65ef891c9bf548dbac1690c3f32e7
+    repo:    https://github.com/clintonskitson/gophercloud.git
     vcs:     git

--- a/rexray/cli/cmds_volume.go
+++ b/rexray/cli/cmds_volume.go
@@ -126,7 +126,7 @@ func (c *CLI) initVolumeCmds() {
 			}
 
 			volumeAttachment, err := c.r.Storage.AttachVolume(
-				c.runAsync, c.volumeID, c.instanceID)
+				c.runAsync, c.volumeID, c.instanceID, c.force)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -151,7 +151,7 @@ func (c *CLI) initVolumeCmds() {
 			}
 
 			err := c.r.Storage.DetachVolume(
-				c.runAsync, c.volumeID, c.instanceID)
+				c.runAsync, c.volumeID, c.instanceID, c.force)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -169,7 +169,7 @@ func (c *CLI) initVolumeCmds() {
 			}
 
 			mountPath, err := c.r.Volume.Mount(
-				c.volumeName, c.volumeID, c.overwriteFs, c.fsType)
+				c.volumeName, c.volumeID, c.overwriteFs, c.fsType, false)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -242,9 +242,11 @@ func (c *CLI) initVolumeFlags() {
 	c.volumeAttachCmd.Flags().BoolVar(&c.runAsync, "runasync", false, "runasync")
 	c.volumeAttachCmd.Flags().StringVar(&c.volumeID, "volumeid", "", "volumeid")
 	c.volumeAttachCmd.Flags().StringVar(&c.instanceID, "instanceid", "", "instanceid")
+	c.volumeAttachCmd.Flags().BoolVar(&c.force, "force", false, "force")
 	c.volumeDetachCmd.Flags().BoolVar(&c.runAsync, "runasync", false, "runasync")
 	c.volumeDetachCmd.Flags().StringVar(&c.volumeID, "volumeid", "", "volumeid")
 	c.volumeDetachCmd.Flags().StringVar(&c.instanceID, "instanceid", "", "instanceid")
+	c.volumeDetachCmd.Flags().BoolVar(&c.force, "force", false, "force")
 	c.volumeMountCmd.Flags().StringVar(&c.volumeID, "volumeid", "", "volumeid")
 	c.volumeMountCmd.Flags().StringVar(&c.volumeName, "volumename", "", "volumename")
 	c.volumeMountCmd.Flags().BoolVar(&c.overwriteFs, "overwritefs", false, "overwritefs")

--- a/test/storage_driver_test.go
+++ b/test/storage_driver_test.go
@@ -387,7 +387,7 @@ func TestStorageDriverAttachVolume(t *testing.T) {
 	}
 	d := <-r.Storage.Drivers()
 	if _, err := d.AttachVolume(
-		false, "", ""); err != nil {
+		false, "", "", false); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -398,7 +398,7 @@ func TestStorageDriverManagerAttachVolume(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := r.Storage.AttachVolume(
-		false, "", ""); err != nil {
+		false, "", "", false); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -409,7 +409,7 @@ func TestStorageDriverManagerAttachVolumeNoDrivers(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := r.Storage.AttachVolume(
-		false, "", ""); err != errors.ErrNoStorageDetected {
+		false, "", "", false); err != errors.ErrNoStorageDetected {
 		t.Fatal(err)
 	}
 }
@@ -421,7 +421,7 @@ func TestStorageDriverDetachVolume(t *testing.T) {
 	}
 	d := <-r.Storage.Drivers()
 	if err := d.DetachVolume(
-		false, "", ""); err != nil {
+		false, "", "", false); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -432,7 +432,7 @@ func TestStorageDriverManagerDetachVolume(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := r.Storage.DetachVolume(
-		false, "", ""); err != nil {
+		false, "", "", false); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -443,7 +443,7 @@ func TestStorageDriverManagerDetachVolumeNoDrivers(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := r.Storage.DetachVolume(
-		false, "", ""); err != errors.ErrNoStorageDetected {
+		false, "", "", false); err != errors.ErrNoStorageDetected {
 		t.Fatal(err)
 	}
 }

--- a/test/volume_driver_test.go
+++ b/test/volume_driver_test.go
@@ -101,7 +101,7 @@ func TestVolumeDriverMount(t *testing.T) {
 		t.Fatal(err)
 	}
 	d := <-r.Volume.Drivers()
-	if _, err := d.Mount("", "", false, ""); err != nil {
+	if _, err := d.Mount("", "", false, "", false); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -111,7 +111,7 @@ func TestVolumeDriverManagerMount(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := r.Volume.Mount("", "", false, ""); err != nil {
+	if _, err := r.Volume.Mount("", "", false, "", false); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -121,7 +121,7 @@ func TestVolumeDriverManagerMountNoDrivers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := r.Volume.Mount("", "", false, ""); err != errors.ErrNoVolumesDetected {
+	if _, err := r.Volume.Mount("", "", false, "", false); err != errors.ErrNoVolumesDetected {
 		t.Fatal(err)
 	}
 }
@@ -256,7 +256,7 @@ func TestVolumeDriverAttach(t *testing.T) {
 		t.Fatal(err)
 	}
 	d := <-r.Volume.Drivers()
-	if _, err := d.Attach("", ""); err != nil {
+	if _, err := d.Attach("", "", false); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -266,7 +266,7 @@ func TestVolumeDriverManagerAttach(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := r.Volume.Attach("", ""); err != nil {
+	if _, err := r.Volume.Attach("", "", false); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -276,7 +276,7 @@ func TestVolumeDriverManagerAttachNoDrivers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := r.Volume.Attach("", ""); err != errors.ErrNoVolumesDetected {
+	if _, err := r.Volume.Attach("", "", false); err != errors.ErrNoVolumesDetected {
 		t.Fatal(err)
 	}
 }
@@ -287,7 +287,7 @@ func TestVolumeDriverDetach(t *testing.T) {
 		t.Fatal(err)
 	}
 	d := <-r.Volume.Drivers()
-	if err := d.Detach("", ""); err != nil {
+	if err := d.Detach("", "", false); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -297,7 +297,7 @@ func TestVolumeDriverManagerDetach(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := r.Volume.Detach("", ""); err != nil {
+	if err := r.Volume.Detach("", "", false); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -307,7 +307,7 @@ func TestVolumeDriverManagerDetachNoDrivers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := r.Volume.Detach("", ""); err != errors.ErrNoVolumesDetected {
+	if err := r.Volume.Detach("", "", false); err != errors.ErrNoVolumesDetected {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
There is now the ability to pre-empt on mounts through the CLI
as well as directly through HTTP/JSON API.  In the case of CLI,
this in invoked through force with attach/detach and preempt with
mount.  Additionally, pre-emption can be enabled globally through
the volume.mountpreempt configuration flag.