### PR TITLE
Fix for not setting Gofig global/user dirs

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -1,11 +1,19 @@
 package core
 
 import (
+	"fmt"
+
 	"github.com/akutz/gofig"
+
+	"github.com/emccode/rexray/util"
 )
 
 func init() {
 	initDrivers()
+
+	gofig.SetGlobalConfigPath(util.EtcDirPath())
+	gofig.SetUserConfigPath(fmt.Sprintf("%s/.rexray", util.HomeDir()))
+
 	gofig.Register(globalRegistration())
 	gofig.Register(driverRegistration())
 }


### PR DESCRIPTION
This patch fixes the issue where the Gofig's global (/etc) and user ($HOME) directories were not set, resulting in the default config files not being loaded.