### PR TITLE
Fix for not setting Gofig config dirs (Rebased)

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -1,11 +1,18 @@
 package core
 
 import (
+	"fmt"
+
 	"github.com/akutz/gofig"
+	"github.com/akutz/gotil"
+
+	"github.com/emccode/rexray/util"
 )
 
 func init() {
 	initDrivers()
+	gofig.SetGlobalConfigPath(util.EtcDirPath())
+	gofig.SetUserConfigPath(fmt.Sprintf("%s/.rexray", gotil.HomeDir()))
 	gofig.Register(globalRegistration())
 	gofig.Register(driverRegistration())
 }


### PR DESCRIPTION
This patch was originally commit d04023572e47e5c18fa549fe7f7de301e8470c63, but it failed to build in CI as it was not rebased off of master prior to being merged. This is the rebased patch.

This patch fixes the issue where the Gofig's global (/etc) and user ($HOME) directories were not set, resulting in the default config files not being loaded.