### PR TITLE
Chopped global flags with rexray in name

### DIFF
--- a/.docs/about/release-notes.md
+++ b/.docs/about/release-notes.md
@@ -208,8 +208,8 @@ users. The commands are now categorized into logical groups:
     Global Flags:
       -c, --config="/Users/akutz/.rexray/config.yaml": The REX-Ray configuration file
       -?, --help[=false]: Help for rexray
-      -h, --rexrayHost="tcp://:7979": The REX-Ray service address
-      -l, --rexrayLogLevel="info": The log level (panic, fatal, error, warn, info, debug)
+      -h, --host="tcp://:7979": The REX-Ray service address
+      -l, --logLevel="info": The log level (panic, fatal, error, warn, info, debug)
       -v, --verbose[=false]: Print verbose help information
 
     Use "rexray [command] --help" for more information about a command.

--- a/.docs/user-guide/config.md
+++ b/.docs/user-guide/config.md
@@ -147,15 +147,17 @@ Nested properties follow these rules for CLI flags:
   * The remaining levels' first characters are all upper-cased with the the
     remaining text of that level left unaltered.
   * All levels are then concatenated together.
+  * See the verbose help for exact global flags using `rexray --help -v`
+    as they may be chopped to minimize verbosity.
 
 The following table illustrates the transformations:
 
 Property Name | Environment Variable | CLI Flag
 --------------|----------------------|-------------
-`rexray.logLevel`    | `REXRAY_LOGLEVEL`    | `--rexrayLogLevel`
-`rexray.osDrivers`   | `REXRAY_OSDRIVERS`   | `--rexrayOsDrivers`
-`rexray.storageDrivers`    | `REXRAY_STORAGEDRIVERS`   | `--rexrayStorageDrivers`
-`rexray.volumeDrivers`    | `REXRAY_VOLUMEDRIVERS`   | `--rexrayVolumeDrivers`
+`rexray.logLevel`    | `REXRAY_LOGLEVEL`    | `--logLevel`
+`rexray.osDrivers`   | `REXRAY_OSDRIVERS`   | `--osDrivers`
+`rexray.storageDrivers`    | `REXRAY_STORAGEDRIVERS`   | `--storageDrivers`
+`rexray.volumeDrivers`    | `REXRAY_VOLUMEDRIVERS`   | `--volumeDrivers`
 
 Another example is a possible configuration of the Amazon Web Services (AWS)
 Elastic Compute Cloud (EC2) storage driver:
@@ -193,7 +195,7 @@ rexray:
 
 However, to specify the same values in an environment variable,
 `REXRAY_STORAGEDRIVERS="ec2 xtremio"`, and as a CLI flag,
-`--rexrayStorageDrivers="ec2 xtremio"`.
+`--storageDrivers="ec2 xtremio"`.
 
 ## Logging
 The `REX-Ray` log level determines the level of verbosity emitted by the

--- a/core/core.go
+++ b/core/core.go
@@ -25,9 +25,11 @@ rexray:
     logLevel: warn
 `)
 	r.Key(gofig.String, "h", "tcp://:7979",
-		"The REX-Ray host", "rexray.host")
+		"The REX-Ray host", "rexray.host",
+		"host")
 	r.Key(gofig.String, "l", "warn",
-		"The log level (error, warn, info, debug)", "rexray.logLevel")
+		"The log level (error, warn, info, debug)", "rexray.logLevel",
+		"logLevel")
 	return r
 }
 
@@ -43,10 +45,13 @@ rexray:
     - docker
 `)
 	r.Key(gofig.String, "", "linux",
-		"The OS drivers to consider", "rexray.osDrivers")
+		"The OS drivers to consider", "rexray.osDrivers",
+		"osDrivers")
 	r.Key(gofig.String, "", "",
-		"The storage drivers to consider", "rexray.storageDrivers")
+		"The storage drivers to consider", "rexray.storageDrivers",
+		"storageDrivers")
 	r.Key(gofig.String, "", "docker",
-		"The volume drivers to consider", "rexray.volumeDrivers")
+		"The volume drivers to consider", "rexray.volumeDrivers",
+		"volumeDrivers")
 	return r
 }

--- a/rexray/cli/cli.go
+++ b/rexray/cli/cli.go
@@ -253,7 +253,7 @@ func (c *CLI) updateLogLevel() {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	log.WithField("rexrayLogLevel", c.logLevel()).Debug("updated log level")
+	log.WithField("logLevel", c.logLevel()).Debug("updated log level")
 }
 
 func (c *CLI) preRun(cmd *cobra.Command, args []string) {

--- a/rexray/cli/service.go
+++ b/rexray/cli/service.go
@@ -173,10 +173,10 @@ func (c *CLI) tryToStartDaemon() {
 	cmdArgs := []string{
 		"start",
 		fmt.Sprintf("--client=%s", client),
-		fmt.Sprintf("--rexrayLogLevel=%v", c.logLevel())}
+		fmt.Sprintf("--logLevel=%v", c.logLevel())}
 
 	if c.host() != "" {
-		cmdArgs = append(cmdArgs, fmt.Sprintf("--rexrayHost=%s", c.host()))
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--host=%s", c.host()))
 	}
 
 	cmd := exec.Command(thisAbsPath, cmdArgs...)


### PR DESCRIPTION
This commit removes the rexray portion of CLI flags to minimize
verbosity when using interactively.