### PR TITLE
Reorder the dependency resolution steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,8 +203,8 @@ _deps:
 			$(PRINT_STATUS); \
 		printf "  ...downloading go dependencies..."; \
 			cd $(BASEDIR); \
+			$(GLIDE) up 2> /dev/null; \
 			go get -d $(GOFLAGS) $(NV); \
-			$(GLIDE) -q up 2> /dev/null; \
 			$(PRINT_STATUS); \
 	fi
 


### PR DESCRIPTION
This patch reorders the dependency resolution steps so that `glide up` occurs prior to `go get -d`.