### PR TITLE
Fixed typo in the Isilon section of the user guide.

### DIFF
--- a/.docs/user-guide/isilon.md
+++ b/.docs/user-guide/isilon.md
@@ -32,7 +32,7 @@ The following items are configurable specific to this driver.
  - `nfsHost` is the configurable host used when mounting exports
 
 ## Activating the Driver
-To activate the XtremIO driver please follow the instructions for
+To activate the Isilon driver please follow the instructions for
 [activating storage drivers](/user-guide/config#activating-storage-drivers),
 using `isilon` as the driver name.
 


### PR DESCRIPTION
Fixed a small typo in the Isilon user guide.  Changed a reference from XtremIO to Isilon.