### PR TITLE
Added unmount before mount

### DIFF
--- a/.docs/user-guide/config.md
+++ b/.docs/user-guide/config.md
@@ -284,7 +284,7 @@ openStack:
 
 Driver|Supported
 ------|---------
-EC2|Yes
+EC2|Yes, HVM only
 OpenStack|With Cinder v2
 ScaleIO|Yes
 Rackspace|No

--- a/.docs/user-guide/gce.md
+++ b/.docs/user-guide/gce.md
@@ -45,7 +45,3 @@ gce:
 ## Configurable Items
 The following items are configurable specific to this driver.
 - [volumeTypes](https://cloud.google.com/compute/docs/reference/latest/diskTypes/list)
-
-## Limitations
-- Debian 8.2 forced mounts via pre-emption results in Input/Output error until
-remounted

--- a/drivers/os/linux/linux.go
+++ b/drivers/os/linux/linux.go
@@ -100,6 +100,10 @@ func (d *driver) Mount(
 		return nil
 	}
 
+	if err := d.Unmount(target); err != nil {
+		return err
+	}
+
 	fsType, err := probeFsType(device)
 	if err != nil {
 		return err


### PR DESCRIPTION
In to ensure that stale device paths are not used,
an unmount is done before a mount occurs.