### PR TITLE
Added volume mount/unmount accounting and control for unmounts

### DIFF
--- a/.docs/user-guide/config.md
+++ b/.docs/user-guide/config.md
@@ -259,7 +259,8 @@ Docker   | docker
 
 The volume driver `docker` is automatically activated.
 
-### Pre-emptive Volume Mount
+## Volume Mount
+### Pre-Emptive
 There is a capability to pre-emptively detach any existing attachments to other
 instances before attempting a mount.  This will enable use cases for
 availability where another instance must be able to take control of a volume
@@ -289,3 +290,32 @@ OpenStack|With Cinder v2
 ScaleIO|Yes
 Rackspace|No
 XtremIO|Yes
+
+## Volume Unmount
+### Ignore Used Count
+By default accounting takes place during operations that are performed
+on `Mount`, `Unmount`, and other operations.  This only has impact when running
+as a service through the HTTP/JSON interface since the counts are persisted
+in memory.  The purpose of respecting the `Used Count` is to ensure that a
+volume is not unmounted until the unmount requests have equaled the mount
+requests.  
+
+In the `Docker` use case if there are multiple containers sharing a volume
+on the same host, the the volume will not be unmounted until the last container
+is stopped.  
+
+The following setting should only be used if you wish to *disable* this
+functionality.  This would make sense if the accounting is being done from
+higher layers and all unmount operations should proceed without control.
+```yaml
+rexray:
+  volume:
+    unmount:
+      ignoreUsedCount: true
+```
+
+Currently a reset of the service will cause the counts to be reset.  This
+will cause issues if *multiple containers* are sharing a volume.  If you are
+sharing volumes, it is recommended that you reset the service along with the
+accompanying container runtime (if this setting is false) to ensure they are
+synchronized.  

--- a/.docs/user-guide/docker.md
+++ b/.docs/user-guide/docker.md
@@ -5,12 +5,34 @@ Build, ship, run on storage made easy
 ---
 
 ### Overview
-`Docker 1.7` established a Volume Driver API that enables persistent volumes
-to be orchestrated with containers.  `REX-Ray` has a `Docker Volume Driver`
-which is compatible with 1.7+.
+`REX-Ray` has a `Docker Volume Driver` which is compatible with 1.7+.
+
+It is suggested that you are running `Docker 1.9.1+` with `REX-Ray` especially
+if you are sharing volumes between containers.
 
 ## Examples
-REX-Ray must be running as a service to serve requests from Docker.  This can be done by running `rexray start`.  
+Below is an example `config.yml` that can be used.  The `volume.mount.preempt`
+is an optional parameter here which enables any host to take control of a
+volume irrespective of whether other hosts are using the volume.  If this is
+set to `false` then mostly plugins ensure `safeety` first for locking the
+volume.
+
+```yaml
+rexray:
+  storageDrivers:
+  - virtualbox
+  volume:
+    mount:
+      preempt: true
+virtualbox:
+  endpoint: http://yourlaptop:18083
+  volumePath: /Users/youruser/VirtualBox Volumes
+  controllerName: SATA
+```
+
+REX-Ray must be running as a service to serve requests from Docker.  This can be
+ done by running `rexray start`.  Make sure you restart REX-Ray if you make
+ configuration changes.
 
     root@ubuntu:/home/ubuntu# ./rexray start
     Starting REX-Ray...SUCESS!
@@ -32,16 +54,20 @@ Create volume with options (1.8+)
 
     docker volume create --driver=rexray --opt=size=5 --name=test
 
-
 ### Extra Options
 option|description
 ------|-----------
 size|Size in GB
 IOPS|IOPS
 volumeType|Type of Volume or Storage Pool
-newFsType|FS Type for Volume if filesystem unknown
-overwriteFs|Overwrite existing known filesystem
 volumeName|Create from an existing volume name
 volumeID|Creat from an existing volume ID
 snapshotName|Create from an existing snapshot name
 snapshotID|Create from an existing snapshot ID
+
+### Caveats
+If you restart the REX-Ray instance while volumes are mounted with Docker,
+then you should also be resetting Docker.  The volume mount accounting will
+be out of sync unless REX-Ray this happens.  In the case of sharing volumes
+between containers, problems will arise when stopping the first container since
+the volume will be unmounted pre-maturely.

--- a/.docs/user-guide/mesos.md
+++ b/.docs/user-guide/mesos.md
@@ -5,11 +5,44 @@ Pooling storage has never been easier...
 ---
 
 ### Overview
+`Mesos` currently includes two containerizer options for tasks.  The first is
+the `Docker` containizer that leverages a Docker runtime to run containers.  In
+this case, refer to the
+[Docker](/user-guide/docker.md) page for more information.  Otherwise,
+the Mesos containerizer is used and the following is important for it.
+
 `Mesos 0.23+` includes modules that enables extensibility for different
-portions the architecture.  The [dvdcli](https://github.com/emccode/dvdcli) and [mesos-module-dvdi](https://github.com/emccode/mesos-module-dvdi) projects enable external volume support with Mesos.
+portions the architecture.  The [dvdcli](https://github.com/emccode/dvdcli) and
+[mesos-module-dvdi](https://github.com/emccode/mesos-module-dvdi) projects
+enable external volume support with Mesos.
 
 ## Examples
-REX-Ray must be running as a service to serve requests from Docker.  This can be done by running `rexray start`.  
+Below is an example `config.yml` file that can be used.  In this case we are
+showing a `virtualbox` driver configuration, but you can use anything here.  We
+do suggest two optional options for the `messos-module-dvdi`.  Setting the
+`volume.mount.preempt` flag ensures any host can pre-empt control of a volume
+from other hosts.  The `volume.unmount.ignoreusedcount` ensures that
+`mesos-module-dvdi` is authoritative when it comes to deciding when to unmount
+volumes.
+
+```yaml
+rexray:
+  storageDrivers:
+  - virtualbox
+  volume:
+    mount:
+      preempt: true
+    unmount:
+      ignoreusedcount: true
+virtualbox:
+  endpoint: http://yourlaptop:18083
+  volumePath: /Users/youruser/VirtualBox Volumes
+  controllerName: SATA
+```      
+
+REX-Ray must be running as a service to serve requests from Docker.  This can
+be done by running `rexray start`.  Make sure you restart REX-Ray if you make
+configuration changes.
 
     root@ubuntu:/home/ubuntu# ./rexray start
     Starting REX-Ray...SUCESS!


### PR DESCRIPTION
This commit introduces an accounting mechanism at the volume
driver manager layer.  It is will always perform counting
of create/mount/unmount operations that are received through
the HTTP/JSON API.  If the rexray.volume.unmount.checkusedcount
is set to true, then it will stop unmounts since it is detecting
that another container is using the mount still.