### PR TITLE
Fixed panic on task cancel

### DIFF
--- a/drivers/storage/ec2/ec2.go
+++ b/drivers/storage/ec2/ec2.go
@@ -657,6 +657,11 @@ func (d *driver) waitVolumeAttach(volumeID, instanceID string) error {
 		if err != nil {
 			return err
 		}
+
+		if len(volume) == 0 {
+			break
+		}
+
 		if volume[0].Status == "attached" {
 			break
 		}


### PR DESCRIPTION
This commit fixes the ec2 driver where if a volume attachmenttask is running 
and it is canceled by the operator, it would typically result in
a panic.  This was caused since the volume attachment would return
nil and it would still be checked for status.