### PR TITLE
Added getvolume check on create

### DIFF
--- a/drivers/storage/ec2/ec2.go
+++ b/drivers/storage/ec2/ec2.go
@@ -376,6 +376,15 @@ func (d *driver) CreateVolume(
 	runAsync bool, volumeName, volumeID, snapshotID, volumeType string,
 	IOPS, size int64, availabilityZone string) (*core.Volume, error) {
 
+	volumes, err := d.GetVolume("", volumeName)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(volumes) > 0 {
+		return nil, goof.WithField("volumeName", volumeName, "volume name already exists")
+	}
+
 	resp, err := d.createVolume(
 		runAsync, volumeName, volumeID, snapshotID, volumeType,
 		IOPS, size, availabilityZone)
@@ -384,7 +393,7 @@ func (d *driver) CreateVolume(
 		return nil, err
 	}
 
-	volumes, err := d.GetVolume(resp.VolumeId, "")
+	volumes, err = d.GetVolume(resp.VolumeId, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit ensures that a volume does not exist by the same name
when created using the ec2 driver.

This brings the driver in line with expected functionality where a 
duplicate volume is unmanageable by RR.