### PR TITLE
Added sub-path for volume mounts and permission setting

### DIFF
--- a/.docs/user-guide/config.md
+++ b/.docs/user-guide/config.md
@@ -319,3 +319,32 @@ will cause issues if *multiple containers* are sharing a volume.  If you are
 sharing volumes, it is recommended that you reset the service along with the
 accompanying container runtime (if this setting is false) to ensure they are
 synchronized.  
+
+## Volume Path (0.3.1)
+When volumes are mounted there can be an additional path that is specified to
+be created and passed as the valid mount point.  This is required for certain
+applications that do not want to place data from the root of a mount point.  
+The default is the `/data` path.  If a value is set by `linux.volume.rootPath`,
+then the default will be overwritten.
+
+If upgrading to 0.3.1 then you can either set this to an empty value, or move
+the internal directory in your existing volumes to `/data`.
+
+```yaml
+rexray:
+linux:
+  volume:
+    rootPath: /data
+```
+
+## Volume FileMode (0.3.1)
+The permissions of the `linux.volume.rootPath` can be set to default values.  At
+each mount, the permissions will be written based on this value.  The default
+is to include the `0700` mode.
+
+```yaml
+rexray:
+linux:
+  volume:
+    fileMode: 0700
+```

--- a/drivers/volume/docker/volume.go
+++ b/drivers/volume/docker/volume.go
@@ -94,7 +94,7 @@ func (d *driver) Mount(volumeName, volumeID string, overwriteFs bool, newFsType 
 	}
 
 	if len(mounts) > 0 {
-		return mounts[0].Mountpoint, nil
+		return d.volumeMountPath(mounts[0].Mountpoint), nil
 	}
 
 	switch {
@@ -123,7 +123,7 @@ func (d *driver) Mount(volumeName, volumeID string, overwriteFs bool, newFsType 
 		return "", err
 	}
 
-	return mountPath, nil
+	return d.volumeMountPath(mountPath), nil
 }
 
 // Unmount will perform the steps to unmount and existing volume and detach
@@ -269,7 +269,7 @@ func (d *driver) Path(volumeName, volumeID string) (string, error) {
 		return "", nil
 	}
 
-	return mounts[0].Mountpoint, nil
+	return d.volumeMountPath(mounts[0].Mountpoint), nil
 }
 
 // Create will create a remote volume
@@ -674,11 +674,20 @@ func (d *driver) NetworkName(volumeName, instanceID string) (string, error) {
 	return volumes[0].NetworkName, nil
 }
 
+func (d *driver) volumeMountPath(target string) string {
+	return fmt.Sprintf("%s%s", target, d.volumeRootPath())
+}
+
+func (d *driver) volumeRootPath() string {
+	return d.r.Config.GetString("linux.volume.rootPath")
+}
+
 func configRegistration() *gofig.Registration {
 	r := gofig.NewRegistration("Docker")
 	r.Key(gofig.String, "", "", "", "docker.volumeType")
 	r.Key(gofig.Int, "", 0, "", "docker.iops")
 	r.Key(gofig.Int, "", 0, "", "docker.size")
 	r.Key(gofig.String, "", "", "", "docker.availabilityZone")
+	r.Key(gofig.String, "", "/data", "", "linux.volume.rootpath")
 	return r
 }


### PR DESCRIPTION
This commit introduces a new setting that ensures that following
the typical mount, that a new directory is created for data
with a default value of /data.  The field is configurable to
ensure compatibility with old versions and future.  The default
permissions on this directory are set to 0700.