### PR TITLE
Fixed XIO bug for pre-emption and volume discovery

### DIFF
--- a/drivers/os/linux/linux.go
+++ b/drivers/os/linux/linux.go
@@ -100,9 +100,6 @@ func (d *driver) Mount(
 	device, target, mountOptions, mountLabel string) error {
 
 	if d.isNfsDevice(device) {
-		if err := d.Unmount(target); err != nil {
-			return err
-		}
 
 		if err := d.nfsMount(device, target); err != nil {
 			return err
@@ -112,10 +109,6 @@ func (d *driver) Mount(
 		os.Chmod(d.volumeMountPath(target), d.fileModeMountPath())
 
 		return nil
-	}
-
-	if err := d.Unmount(target); err != nil {
-		return err
 	}
 
 	fsType, err := probeFsType(device)


### PR DESCRIPTION
The cautionary unmount was is now performed earlier so that
prior to attaching a device, the mount table is clear.