### PR TITLE
Update docs to reflect testing with pre-emption

### DIFF
--- a/.docs/user-guide/config.md
+++ b/.docs/user-guide/config.md
@@ -285,10 +285,13 @@ openStack:
 
 Driver|Supported
 ------|---------
-EC2|Yes, HVM only
+EC2|Yes, no Ubuntu support
+Isilon|Not yet
 OpenStack|With Cinder v2
 ScaleIO|Yes
 Rackspace|No
+VirtualBox|Yes
+VMAX|Not yet
 XtremIO|Yes
 
 ## Volume Unmount


### PR DESCRIPTION
The docs now reflect latest status with pre-emption.  The latest testing indicates that the EC2 drivers included in Ubuntu for blkfront (xvd) have a bug that has not been resolved in regards to forced detach (https://bugs.launchpad.net/ubuntu/+source/linux-ec2/+bug/1326870).