### PR TITLE
Removed debugging lines in openstack driver

### DIFF
--- a/drivers/storage/openstack/openstack.go
+++ b/drivers/storage/openstack/openstack.go
@@ -130,14 +130,11 @@ func (d *driver) Init(r *core.RexRay) error {
 			"error getting newBlockStorageV1", err)
 	}
 
-	fmt.Println(fmt.Sprintf("%v", d.clientBlockStorage))
-
 	if d.clientBlockStoragev2, err = openstack.NewBlockStorageV2(d.provider,
 		gophercloud.EndpointOpts{Region: d.region}); err != nil {
 		return goof.WithFieldsE(fields,
 			"error getting newBlockStorageV2", err)
 	}
-	fmt.Println(fmt.Sprintf("%v", d.clientBlockStoragev2))
 
 	log.WithField("provider", providerName).Info("storage driver initialized")
 


### PR DESCRIPTION
This commit removes verbose debugging lines that were in place
during driver updates.