### PR TITLE
Bugfix for SIO and pre-emption

### DIFF
--- a/drivers/storage/scaleio/scaleio.go
+++ b/drivers/storage/scaleio/scaleio.go
@@ -554,20 +554,18 @@ func (d *driver) DetachVolume(
 	targetVolume.Volume = volumes[0]
 
 	unmapVolumeSdcParam := &types.UnmapVolumeSdcParam{
-		SdcID:                d.sdc.Sdc.ID,
+		SdcID:                "",
 		IgnoreScsiInitiators: "true",
 		AllSdcs:              "",
 	}
 
 	if force {
 		unmapVolumeSdcParam.AllSdcs = "true"
+	} else {
+		unmapVolumeSdcParam.SdcID = d.sdc.Sdc.ID
 	}
 
-	// need to detect if unmounted first
-	err = targetVolume.UnmapVolumeSdc(unmapVolumeSdcParam)
-	if err != nil {
-		return goof.WithFieldsE(fields, "error unmapping volume sdc", err)
-	}
+	_ = targetVolume.UnmapVolumeSdc(unmapVolumeSdcParam)
 
 	log.WithFields(log.Fields{
 		"provider": providerName,


### PR DESCRIPTION
This commit fixes the scenario where the volume cannot be detached
after a certain order of events.  The parameter was also clarified
to detach all verus explicitly calling an instance ID.