### PR TITLE
Bugfix/virtualbox docs version

### DIFF
--- a/.docs/user-guide/virtualbox.md
+++ b/.docs/user-guide/virtualbox.md
@@ -70,6 +70,9 @@ virtualbox:
 ```
 
 ## Caveats
+- The VBoxWebSrv SOAP API changed between v4 and v5.  This functionality
+  works against `4.3.28` and likely other v4 versions only.  We are
+  investigating support for same features under v5.
 - This driver was developed against Ubuntu 14.04.3 but should work with
   others.
 - Snapshot and create volume from volume functionality is not available


### PR DESCRIPTION
This PR introduces some documentation updates for VB.  It calls out that v4 is the supported version for the driver currently versus the latest v5.0.