### PR TITLE
Removed travis caching for Go packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,5 +51,4 @@ deploy:
 cache:
   apt: true
   directories:
-    - $GOPATH/pkg
     - $HOME/.opt


### PR DESCRIPTION
The caching of Go packages is causing inconsistency between the
builds that are supposed to occur from scratch.

This fix addresses issues around the error details being squashed
since the wrong logrus package was being used.

https://github.com/emccode/rexray/issues/221