### PR TITLE
Updates for VirtualBox 5.0.10

### DIFF
--- a/.docs/user-guide/storage-providers/virtualbox.md
+++ b/.docs/user-guide/storage-providers/virtualbox.md
@@ -29,6 +29,7 @@ only.  Ensure that your VM has *pre-created* this controller and it is
 named `SATA`.  Otherwise the `controllerName` field must be populated
 with the name of the controller you wish to use.
 
+VirtualBox 5.0.10+ must be used.
 
 ## Configuration
 The following is an example configuration of the VirtualBox driver.  
@@ -75,5 +76,6 @@ virtualbox:
   investigating support for same features under v5.
 - This driver was developed against Ubuntu 14.04.3 but should work with
   others.
-- Snapshot and create volume from volume functionality is not available
-  since VirtualBox does not support volume snapshots directly.
+- Snapshot and create volume from volume functionality is not
+  available yet with this driver.
+- The driver supports VirtualBox 5.0.10+

--- a/drivers/storage/virtualbox/virtualbox.go
+++ b/drivers/storage/virtualbox/virtualbox.go
@@ -292,12 +292,21 @@ func (d *driver) CreateVolume(
 
 	size = size * 1024 * 1024 * 1024
 
+	volumes, err := d.GetVolume("", volumeName)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(volumes) > 0 {
+		return nil, goof.WithField(volumeName, "volumeName", "volume exists already")
+	}
+
 	volume, err := d.createVolume(volumeName, size)
 	if err != nil {
 		return nil, goof.WithFieldsE(fields, "error creating new volume", err)
 	}
 
-	volumes, err := d.GetVolume(volume.ID, "")
+	volumes, err = d.GetVolume(volume.ID, "")
 	if err != nil {
 		return nil, err
 	}
@@ -464,7 +473,7 @@ func (d *driver) createVolume(name string, size int64) (*vbox.Medium, error) {
 	d.checkSession()
 
 	if name == "" {
-		return nil, goof.New("name in empty")
+		return nil, goof.New("name is empty")
 	}
 
 	return d.virtualbox.CreateMedium("vmdk", d.storageLocation(name), size)

--- a/glide.yaml
+++ b/glide.yaml
@@ -69,6 +69,6 @@ import:
     repo:    https://github.com/emccode/goisilon
     vcs:     git
   - package: github.com/appropriate/go-virtualboxclient
-    ref:     967c729a049434d84c4a6d2e5c650f7c57257060
+    ref:     e0978ab2ed407095400a69d5933958dd260058cd
     repo:    https://github.com/clintonskitson/go-virtualboxclient
     vcs:     git


### PR DESCRIPTION
This commit brings support up to VirtualBox 5.0.10.  There is
a slight difference in the underlying SOAP API which is updated
through some small tweaks here and the unldering go-virtualbox
package.