### PR TITLE
Bugfix for change in Glide behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+glide.lock
 .site/
 site/
 .build/*/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,18 @@
 # configure make
 export MAKEFLAGS := $(MAKEFLAGS) --no-print-directory -k
 
+# MAKE_LOG_LEVEL can be 0=quiet, 1=error, 2=verbose
+MAKE_LOG_LEVEL ?= 0
+ifeq ($(MAKE_LOG_LEVEL),0)
+	MAKE_LOG_FD := &> /dev/null
+else
+ifeq ($(MAKE_LOG_LEVEL),1)
+	MAKE_LOG_FD := 1> /dev/null
+else
+	MAKE_LOG_FD :=
+endif
+endif
+
 # store the current working directory
 CWD := $(shell pwd)
 
@@ -201,9 +213,11 @@ _deps:
 		printf "  ...installing glide..."; \
 		go get github.com/Masterminds/glide; \
 			$(PRINT_STATUS); \
-		printf "  ...downloading go dependencies..."; \
+		printf "  ...glide up..."; \
 			cd $(BASEDIR); \
-			$(GLIDE) up 2> /dev/null; \
+			$(GLIDE) up $(MAKE_LOG_FD); \
+			$(PRINT_STATUS); \
+		printf "  ...go get..."; \
 			go get -d $(GOFLAGS) $(NV); \
 			$(PRINT_STATUS); \
 	fi

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,8 @@
 package: github.com/emccode/rexray
 import:
+  - package: github.com/akutz/goof
+    ref:     master
+    vcs:     git
   - package: github.com/spf13/pflag
     ref:     b084184666e02084b8ccb9b704bf0d79c466eb1d
     repo:    https://github.com/spf13/pflag
@@ -28,9 +31,6 @@ import:
     ref:     v0.1.1
     vcs:     git
   - package: github.com/akutz/gofig
-    ref:     master
-    vcs:     git
-  - package: github.com/akutz/goof
     ref:     master
     vcs:     git
   - package: github.com/akutz/gotil


### PR DESCRIPTION
This patch fixes an issue (#221) where Glide no longer seems to handle transitive dependencies correctly unless the referencing dependency is ordered above another that may have a conflict.

In this instance the dependency upon `github.com/akutz/goof` was moved to the top of the `glide.yaml` file so that its dependency upon a fork of the `logrus` project would be honored when glide evaluated the transitive dependency chain.

@clintonskitson, FWIW, the reason you didn't see any speedup in builds with caching is how glide now operates. It apparently downloads *everything* by default, rendering the package cache somewhat irrelevant due to the fact that glide by default rebuilds it as it downloads dependencies anyway. 

In the future we should eliminate transitive dependencies if we wish to avoid this so we can disable glide's recursive dependency feature.

@clintonskitson, I also made some small changes in the `Makefile` so that if you set `MAKE_LOG_LEVEL` to `2` via an environment variable, glide will output the log of what dependencies it downloads. This should allow us to confirm the correct `logrus` branch is being set to coincide with the testing I did locally.