### PR TITLE
Updated openstack options for reauth capability

### DIFF
--- a/drivers/storage/openstack/openstack.go
+++ b/drivers/storage/openstack/openstack.go
@@ -184,6 +184,7 @@ func (d *driver) getAuthOptions() gophercloud.AuthOptions {
 		TenantName:       d.tenantName(),
 		DomainID:         d.domainID(),
 		DomainName:       d.domainName(),
+		AllowReauth:      true,
 	}
 }
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -49,7 +49,7 @@ import:
     repo:    https://github.com/akutz/yaml.git
     vcs:     git
   - package: github.com/rackspace/gophercloud
-    ref:     30f929fcb1c65ef891c9bf548dbac1690c3f32e7
+    ref:     42196eaf5b93739d335921404bb7c5f2205fceb3
     repo:    https://github.com/clintonskitson/gophercloud.git
     vcs:     git
   - package: google.golang.org/api/compute/v1


### PR DESCRIPTION
The reauthenticate flag is now set by default for openstack
to handle situations where keystone has expired an existing
token.