### PR TITLE
Added documentation pointing to vagrant example for automation

### DIFF
--- a/.docs/user-guide/automation.md
+++ b/.docs/user-guide/automation.md
@@ -99,4 +99,8 @@ ToDo
 
 <br>
 ## Vagrant
-ToDo
+Using Vagrant is a great option to deploy pre-configured REX-Ray nodes including
+Docker using the VirtualBox driver.  All volume requests are handled using
+VirtualBox's Virtual Media.
+
+[here](https://github.com/emccode/vagrant/tree/master/rexray).


### PR DESCRIPTION
This commit includes a reference to a Vagrant repo that enables
a simple deployment of REX-Ray using VirtualBox.

Thanks @jonasrosland 