### PR TITLE
Fix documentation for correct configuraiton file name

### DIFF
--- a/.docs/index.md
+++ b/.docs/index.md
@@ -67,7 +67,7 @@ $ curl -sSL https://dl.bintray.com/emccode/rexray/install | sh -
 
 ### Configuring REX-Ray
 Create a configuration file on the host at `/etc/rexray` in YAML format called
-`rexray.yml` (this file can be created with `vi` or transferred over via `scp`
+`config.yml` (this file can be created with `vi` or transferred over via `scp`
   or `ftp`). Here is a simple example for using Amazon EC2:
 ```
 rexray:


### PR DESCRIPTION
The documentation said that REX-Ray expected to see rexray.yml within /etc/rexray but it should be config.yml

Signed-off-by: Kendrick Coleman <kendrickcoleman@gmail.com>