### PR TITLE
Bugfix for stale PID file

### DIFF
--- a/rexray/cli/service.go
+++ b/rexray/cli/service.go
@@ -28,10 +28,24 @@ func (c *CLI) start() {
 		pid, pidErr := util.ReadPidFile()
 		if pidErr != nil {
 			fmt.Printf("Error reading REX-Ray PID file at %s\n", pidFile)
-		} else {
-			fmt.Printf("REX-Ray already running at PID %d\n", pid)
+			panic(1)
 		}
-		panic(1)
+
+		rrproc, err := findProcess(pid)
+		if err != nil {
+			fmt.Printf("Error finding process for PID %d", pid)
+			panic(1)
+		}
+
+		if rrproc != nil {
+			fmt.Printf("REX-Ray already running at PID %d\n", pid)
+			panic(1)
+		}
+
+		if err := os.RemoveAll(pidFile); err != nil {
+			fmt.Println("Error removing REX-Ray PID file")
+			panic(1)
+		}
 	}
 
 	if c.fg || c.client != "" {

--- a/rexray/cli/service_unix.go
+++ b/rexray/cli/service_unix.go
@@ -1,0 +1,26 @@
+// +build darwin dragonfly freebsd !android,linux netbsd openbsd solaris
+
+package cli
+
+import (
+	"os"
+	"syscall"
+)
+
+func findProcess(pid int) (*os.Process, error) {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return nil, err
+	}
+
+	// make sure that a process with this pid is actually running and to
+	// which we have access
+	if err := syscall.Kill(p.Pid, syscall.Signal(0)); err != nil {
+		if err.Error() == "no such process" {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return p, nil
+}

--- a/rexray/cli/service_windows.go
+++ b/rexray/cli/service_windows.go
@@ -1,0 +1,9 @@
+package cli
+
+import (
+	"os"
+)
+
+func findProcess(pid int) (*os.Process, error) {
+	return os.FindProcess(pid)
+}


### PR DESCRIPTION
This patch fixes a bug (#258) that occurs when REX-Ray is running as a service and is interrupted, leaving behind a stale PID file. If the file contains a PID and the PID points to a non-existent process then the PID files is removed and REX-Ray is started normally.