### PR TITLE
Added boot2docker to supported operating systems

### DIFF
--- a/.docs/index.md
+++ b/.docs/index.md
@@ -36,6 +36,7 @@ Debian   | Yes          | Yes
 RedHat   | Yes          | Yes
 CentOS   | Yes          | Yes
 CoreOS   | Yes          | Yes
+TinyLinux (boot2docker)| Yes          | Yes
 OS X     | Yes          | No
 Windows  | No           | No
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ We explicitly support the following operating system distributions.
 - CentOS
 - CoreOS
 - OSX
+- TinyLinux (boot2docker)
 
 ## Installation
 The following command will install the REX-Ray client-server tool.  If using


### PR DESCRIPTION
This commit add the reference to Tiny Linux and boot2docker to
the supported operating systems.