### PR TITLE
Updated unit file for restart

### DIFF
--- a/rexray/cli/installer.go
+++ b/rexray/cli/installer.go
@@ -327,6 +327,8 @@ Description=rexray
 Before=docker.service
 
 [Service]
+Restart=always
+RestartSec=5
 EnvironmentFile={{.EnvFile}}
 ExecStart={{.RexrayBin}} start -f
 ExecReload=/bin/kill -HUP $MAINPID


### PR DESCRIPTION
This commit introduces the ability for SystemD to restart
the service when it fails.  In the case of a system start
where dependencies for driver starts cannot be satisfied,
the service would previously just fail to start.  Setting
the restart enables retries until the storage driver
can be initialized.