### PR TITLE
Added support for Volume Driver with Docker 1.10

### DIFF
--- a/.docs/index.md
+++ b/.docs/index.md
@@ -104,7 +104,7 @@ $ rexray start
 ```
 
 ### Example of REX-Ray with Docker
-Docker 1.9.1+ is recommended to use REX-Ray as a
+Docker 1.10+ is recommended to use REX-Ray as a
 [Docker Volume Driver Plugin](https://docs.docker.com/extend/plugins_volume/).
 
 The following example uses two Amazon EC2 Virtual Machines, `EC2a` and `EC2b`,

--- a/.docs/user-guide/third-party/docker.md
+++ b/.docs/user-guide/third-party/docker.md
@@ -7,7 +7,7 @@ Build, ship, run on storage made easy
 ### Overview
 `REX-Ray` has a `Docker Volume Driver` which is compatible with 1.7+.
 
-It is suggested that you are running `Docker 1.9.1+` with `REX-Ray` especially
+It is suggested that you are running `Docker 1.10+` with `REX-Ray` especially
 if you are sharing volumes between containers.
 
 ## Examples

--- a/core/drivers_volume.go
+++ b/core/drivers_volume.go
@@ -10,6 +10,9 @@ import (
 // VolumeOpts is a map of options used when creating a new volume
 type VolumeOpts map[string]string
 
+// Volume is a map of a volume
+type VolumeMap map[string]string
+
 // VolumeDriver is the interface implemented by types that provide volume
 // introspection and management.
 type VolumeDriver interface {
@@ -33,6 +36,12 @@ type VolumeDriver interface {
 
 	// Remove will remove a volume of volumeName.
 	Remove(volumeName string) error
+
+	// Get will return a specific volume
+	Get(volumeName string) (VolumeMap, error)
+
+	// List will return all volumes
+	List() ([]VolumeMap, error)
 
 	// Attach will attach a volume based on volumeName to the instance of
 	// instanceID.
@@ -242,6 +251,22 @@ func (r *vdm) Path(volumeName, volumeID string) (string, error) {
 		return d.Path(volumeName, volumeID)
 	}
 	return "", errors.ErrNoVolumesDetected
+}
+
+// Get will return a specific volume
+func (r *vdm) Get(volumeName string) (VolumeMap, error) {
+	for _, d := range r.drivers {
+		return d.Get(volumeName)
+	}
+	return nil, errors.ErrNoVolumesDetected
+}
+
+// Get will return all volumes
+func (r *vdm) List() ([]VolumeMap, error) {
+	for _, d := range r.drivers {
+		return d.List()
+	}
+	return nil, errors.ErrNoVolumesDetected
 }
 
 // Create will create a new volume with the volumeName and opts.

--- a/drivers/mock/mock_volume_driver.go
+++ b/drivers/mock/mock_volume_driver.go
@@ -61,6 +61,14 @@ func (m *mockVolDriver) Remove(volumeName string) error {
 	return nil
 }
 
+func (m *mockVolDriver) Get(volumeName string) (core.VolumeMap, error) {
+	return nil, nil
+}
+
+func (m *mockVolDriver) List() ([]core.VolumeMap, error) {
+	return nil, nil
+}
+
 func (m *mockVolDriver) Attach(volumeName, instanceID string, force bool) (string, error) {
 	return "", nil
 }

--- a/test/volume_driver_test.go
+++ b/test/volume_driver_test.go
@@ -188,6 +188,67 @@ func TestVolumeDriverManagerPathNoDrivers(t *testing.T) {
 	}
 }
 
+func TestVolumeDriverGet(t *testing.T) {
+	r, err := getRexRay()
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := <-r.Volume.Drivers()
+	if _, err := d.Get(""); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVolumeDriverManagerGet(t *testing.T) {
+	r, err := getRexRay()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Volume.Get(""); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVolumeDriverManagerGetNoDrivers(t *testing.T) {
+	r, err := getRexRayNoDrivers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Volume.Get(""); err != errors.ErrNoVolumesDetected {
+		t.Fatal(err)
+	}
+}
+
+func TestVolumeDriverList(t *testing.T) {
+	r, err := getRexRay()
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := <-r.Volume.Drivers()
+	if _, err := d.List(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVolumeDriverManagerList(t *testing.T) {
+	r, err := getRexRay()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Volume.List(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVolumeDriverManagerListNoDrivers(t *testing.T) {
+	r, err := getRexRayNoDrivers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Volume.List(); err != errors.ErrNoVolumesDetected {
+		t.Fatal(err)
+	}
+}
 func TestVolumeDriverCreate(t *testing.T) {
 	r, err := getRexRay()
 	if err != nil {


### PR DESCRIPTION
This commit introduces new functionality that is exposed to the
Docker Volume Driver in Engine 1.10.  Calls for Get/List are
now implemented to enable the engine to rely on volume driver
to return list of existing volumes.  A list locally is no longer
stored which means the array is the single source of truth
for available volumes.