### PR TITLE
Config-Based Module Support

### DIFF
--- a/daemon/daemon_modules.go
+++ b/daemon/daemon_modules.go
@@ -5,6 +5,6 @@ package daemon
 import (
 	// load the modules
 	_ "github.com/emccode/rexray/daemon/module/admin"
-	_ "github.com/emccode/rexray/daemon/module/docker/remotevolumedriver"
+	// _ "github.com/emccode/rexray/daemon/module/docker/remotevolumedriver"
 	_ "github.com/emccode/rexray/daemon/module/docker/volumedriver"
 )

--- a/daemon/module/docker/remotevolumedriver/notests.go
+++ b/daemon/module/docker/remotevolumedriver/notests.go
@@ -1,0 +1,1 @@
+package remotevolumedriver

--- a/daemon/module/docker/remotevolumedriver/remvoldriver.go
+++ b/daemon/module/docker/remotevolumedriver/remvoldriver.go
@@ -1,3 +1,5 @@
+// +build ignore
+
 package remotevolumedriver
 
 import (

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -2,8 +2,9 @@ package volume
 
 import (
 	// loads the volume drivers
-	"github.com/akutz/gofig"
 	_ "github.com/emccode/rexray/drivers/volume/docker"
+
+	"github.com/akutz/gofig"
 )
 
 func init() {

--- a/rexray/cli/cli.go
+++ b/rexray/cli/cli.go
@@ -95,8 +95,8 @@ type CLI struct {
 	mountLabel              string
 	fsType                  string
 	overwriteFs             bool
-	moduleTypeID            int32
-	moduleInstanceID        int32
+	moduleTypeName          string
+	moduleInstanceName      string
 	moduleInstanceAddress   string
 	moduleInstanceStart     bool
 	moduleConfig            []string
@@ -266,6 +266,8 @@ func (c *CLI) preRun(cmd *cobra.Command, args []string) {
 	}
 
 	c.updateLogLevel()
+
+	c.r.Config = c.r.Config.Scope("rexray.modules.default-docker")
 
 	if isHelpFlag(cmd) {
 		cmd.Help()

--- a/rexray/cli/cmds_module.go
+++ b/rexray/cli/cmds_module.go
@@ -105,12 +105,11 @@ func (c *CLI) initModuleCmds() {
 				panic(addrErr)
 			}
 
-			if c.moduleTypeID == -1 || c.moduleInstanceAddress == "" {
+			if c.moduleTypeName == "" || c.moduleInstanceAddress == "" {
 				cmd.Usage()
 				return
 			}
 
-			modTypeIDStr := fmt.Sprintf("%d", c.moduleTypeID)
 			modInstStartStr := fmt.Sprintf("%v", c.moduleInstanceStart)
 
 			u := fmt.Sprintf("http://%s/r/module/instances", addr)
@@ -121,19 +120,21 @@ func (c *CLI) initModuleCmds() {
 			}
 
 			log.WithFields(log.Fields{
-				"url":     u,
-				"typeId":  modTypeIDStr,
-				"address": c.moduleInstanceAddress,
-				"start":   modInstStartStr,
-				"config":  cfgJSON}).Debug("post create module instance")
+				"url":      u,
+				"name":     c.moduleInstanceName,
+				"typeName": c.moduleTypeName,
+				"address":  c.moduleInstanceAddress,
+				"start":    modInstStartStr,
+				"config":   cfgJSON}).Debug("post create module instance")
 
 			client := &http.Client{}
 			resp, respErr := client.PostForm(u,
 				url.Values{
-					"typeId":  {modTypeIDStr},
-					"address": {c.moduleInstanceAddress},
-					"start":   {modInstStartStr},
-					"config":  {cfgJSON},
+					"name":     {c.moduleInstanceName},
+					"typeName": {c.moduleTypeName},
+					"address":  {c.moduleInstanceAddress},
+					"start":    {modInstStartStr},
+					"config":   {cfgJSON},
 				})
 			if respErr != nil {
 				panic(respErr)
@@ -160,13 +161,13 @@ func (c *CLI) initModuleCmds() {
 				panic(addrErr)
 			}
 
-			if c.moduleInstanceID == -1 {
+			if c.moduleInstanceName == "" {
 				cmd.Usage()
 				return
 			}
 
 			u := fmt.Sprintf(
-				"http://%s/r/module/instances/%d/start", addr, c.moduleInstanceID)
+				"http://%s/r/module/instances/%s/start", addr, c.moduleInstanceName)
 
 			client := &http.Client{}
 			resp, respErr := client.Get(u)
@@ -187,8 +188,11 @@ func (c *CLI) initModuleCmds() {
 }
 
 func (c *CLI) initModuleFlags() {
-	c.moduleInstancesCreateCmd.Flags().Int32VarP(&c.moduleTypeID, "id",
-		"i", -1, "The ID of the module type to instance")
+	c.moduleInstancesCreateCmd.Flags().StringVarP(&c.moduleTypeName, "typeName",
+		"t", "", "The name of the module type to instance")
+
+	c.moduleInstancesCreateCmd.Flags().StringVarP(&c.moduleInstanceName, "name",
+		"n", "", "The name of the new module instance")
 
 	c.moduleInstancesCreateCmd.Flags().StringVarP(&c.moduleInstanceAddress,
 		"address", "a", "",
@@ -203,6 +207,6 @@ func (c *CLI) initModuleFlags() {
 		"A comma-seperated string of key=value pairs used by some module "+
 			"types for custom configuraitons.")
 
-	c.moduleInstancesStartCmd.Flags().Int32VarP(&c.moduleInstanceID, "id",
-		"i", -1, "The ID of the module instance to start")
+	c.moduleInstancesStartCmd.Flags().StringVarP(&c.moduleInstanceName, "name",
+		"n", "", "The name of the module instance to start")
 }


### PR DESCRIPTION
This patch adds support for configuration modules via the REX-Ray configuration source. For example, the following configuration is loaded by default:

```yaml
rexray:
    modules:
        default-admin:
            type: admin
            desc: The default admin module.
            host: tcp://127.0.0.1:7979
        default-docker:
            type: docker
            desc: The default docker module.
            host: unix:///run/docker/plugins/rexray.sock
            spec: /etc/docker/plugins/rexray.spec
```

The above configuration indicates that there are two modules that need to be initialized and started:

  1. `default-admin`
  2. `default-docker`

Default modules can be overridden in a custom configuration file by simply using the same names as above.

If the `host` or `spec` properties are not defined for a docker module, then the sanitized name of the module is used to build the paths to a socket and spec file. For example:

```
rexray:
    modules:
        "isilon 2":
            type: docker
```

The above configuration would create a Docker module hosted using a socket file at `unix:///run/docker/plugins/isilon-2.sock` and spec file at `/etc/docker/plugins/isilon-2.spec`.

If the configuration file is used to override part of the `default-docker` module's configuration, for example its description, it's also possible to omit the `default-docker` module's `host` and `spec` properties as well. The difference is that the `default-docker` module's `host` and `spec` properties will default to values based not on the module name but `unix:///run/docker/plugins/rexray` and `/etc/docker/plugins/rexray.spec`.