### PR TITLE
Add REX-Ray Context

### DIFF
--- a/core/drivers_os.go
+++ b/core/drivers_os.go
@@ -86,9 +86,10 @@ func (r *odm) GetMounts(
 	deviceName, mountPoint string) (MountInfoArray, error) {
 	for _, d := range r.drivers {
 		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
 			"deviceName": deviceName,
 			"mountPoint": mountPoint,
-			"driverName": d.Name()}).Info("getting mounts")
+			"driverName": d.Name()}).Info("odm.GetMounts")
 		mounts, err := d.GetMounts(deviceName, mountPoint)
 		if err != nil {
 			return nil, err
@@ -101,8 +102,9 @@ func (r *odm) GetMounts(
 func (r *odm) Mounted(mountPoint string) (bool, error) {
 	for _, d := range r.drivers {
 		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
 			"mountPoint": mountPoint,
-			"driverName": d.Name()}).Info("checking filesystem mount")
+			"driverName": d.Name()}).Info("odm.Mounted")
 		return d.Mounted(mountPoint)
 	}
 	return false, errors.ErrNoOSDetected
@@ -111,8 +113,9 @@ func (r *odm) Mounted(mountPoint string) (bool, error) {
 func (r *odm) Unmount(mountPoint string) error {
 	for _, d := range r.drivers {
 		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
 			"mountPoint": mountPoint,
-			"driverName": d.Name()}).Info("unmounting filesystem")
+			"driverName": d.Name()}).Info("odm.Unmount")
 		return d.Unmount(mountPoint)
 	}
 	return errors.ErrNoOSDetected
@@ -122,11 +125,12 @@ func (r *odm) Mount(
 	device, target, mountOptions, mountLabel string) error {
 	for _, d := range r.drivers {
 		log.WithFields(log.Fields{
+			"moduleName":   r.rexray.Context,
 			"device":       device,
 			"target":       target,
 			"mountOptions": mountOptions,
 			"mountLabel":   mountLabel,
-			"driverName":   d.Name()}).Info("mounting filesystem")
+			"driverName":   d.Name()}).Info("odm.Mount")
 		return d.Mount(device, target, mountOptions, mountLabel)
 	}
 	return errors.ErrNoOSDetected
@@ -140,11 +144,12 @@ func (r *odm) Format(
 	deviceName, fsType string, overwriteFs bool) error {
 	for _, d := range r.drivers {
 		log.WithFields(log.Fields{
+			"moduleName":  r.rexray.Context,
 			"deviceName":  deviceName,
 			"fsType":      fsType,
 			"overwriteFs": overwriteFs,
 			"driverName":  d.Name()}).Info(
-			"formatting if blank or overwriteFs specified")
+			"odm.Format")
 		if r.isNfsDevice(deviceName) {
 			return nil
 		}

--- a/core/drivers_storage.go
+++ b/core/drivers_storage.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"sync"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/emccode/rexray/core/errors"
 )
 
@@ -316,6 +317,9 @@ func (r *sdm) GetInstances() ([]*Instance, error) {
 
 func (r *sdm) GetInstance() (*Instance, error) {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
+			"driverName": d.Name()}).Info("sdm.GetInstance")
 		return d.GetInstance()
 	}
 	return nil, errors.ErrNoStorageDetected
@@ -323,6 +327,11 @@ func (r *sdm) GetInstance() (*Instance, error) {
 
 func (r *sdm) GetVolume(volumeID, volumeName string) ([]*Volume, error) {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
+			"driverName": d.Name(),
+			"volumeName": volumeName,
+			"volumeID":   volumeID}).Info("sdm.GetVolume")
 		return d.GetVolume(volumeID, volumeName)
 	}
 	return nil, errors.ErrNoStorageDetected
@@ -330,6 +339,12 @@ func (r *sdm) GetVolume(volumeID, volumeName string) ([]*Volume, error) {
 
 func (r *sdm) GetSnapshot(volumeID, snapshotID, snapshotName string) ([]*Snapshot, error) {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName":   r.rexray.Context,
+			"driverName":   d.Name(),
+			"volumeID":     volumeID,
+			"snapshotID":   snapshotID,
+			"snapshotName": snapshotName}).Info("sdm.GetSnapshot")
 		return d.GetSnapshot(volumeID, snapshotID, snapshotName)
 	}
 	return nil, errors.ErrNoStorageDetected
@@ -338,6 +353,13 @@ func (r *sdm) GetSnapshot(volumeID, snapshotID, snapshotName string) ([]*Snapsho
 func (r *sdm) CreateSnapshot(runAsync bool,
 	snapshotName, volumeID, description string) ([]*Snapshot, error) {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName":   r.rexray.Context,
+			"driverName":   d.Name(),
+			"runAsync":     runAsync,
+			"snapshotName": snapshotName,
+			"volumeID":     volumeID,
+			"description":  description}).Info("sdm.CreateSnapshot")
 		return d.CreateSnapshot(runAsync, snapshotName, volumeID, description)
 	}
 	return nil, errors.ErrNoStorageDetected
@@ -345,6 +367,11 @@ func (r *sdm) CreateSnapshot(runAsync bool,
 
 func (r *sdm) RemoveSnapshot(snapshotID string) error {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
+			"driverName": d.Name(),
+			"snapshotID": snapshotID}).Info("sdm.RemoveSnapshot")
+
 		return d.RemoveSnapshot(snapshotID)
 	}
 	return errors.ErrNoStorageDetected
@@ -354,6 +381,17 @@ func (r *sdm) CreateVolume(runAsync bool,
 	volumeName, volumeID, snapshotID, volumeType string,
 	IOPS, size int64, availabilityZone string) (*Volume, error) {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName":       r.rexray.Context,
+			"driverName":       d.Name(),
+			"runAsync":         runAsync,
+			"volumeName":       volumeName,
+			"volumeID":         volumeID,
+			"snapshotID":       snapshotID,
+			"volumeType":       volumeType,
+			"IOPS":             IOPS,
+			"size":             size,
+			"availabilityZone": availabilityZone}).Info("sdm.CreateVolume")
 		return d.CreateVolume(
 			runAsync, volumeName, volumeID, snapshotID, volumeType,
 			IOPS, size, availabilityZone)
@@ -363,6 +401,10 @@ func (r *sdm) CreateVolume(runAsync bool,
 
 func (r *sdm) RemoveVolume(volumeID string) error {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
+			"driverName": d.Name(),
+			"volumeID":   volumeID}).Info("sdm.RemoveVolume")
 		return d.RemoveVolume(volumeID)
 	}
 	return errors.ErrNoStorageDetected
@@ -372,6 +414,13 @@ func (r *sdm) AttachVolume(
 	runAsync bool,
 	volumeID, instanceID string, force bool) ([]*VolumeAttachment, error) {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
+			"driverName": d.Name(),
+			"runAsync":   runAsync,
+			"volumeID":   volumeID,
+			"instanceID": instanceID,
+			"force":      force}).Info("sdm.AttachVolume")
 		return d.AttachVolume(runAsync, volumeID, instanceID, force)
 	}
 	return nil, errors.ErrNoStorageDetected
@@ -381,6 +430,12 @@ func (r *sdm) DetachVolume(
 	runAsync bool,
 	volumeID, instanceID string, force bool) error {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
+			"driverName": d.Name(),
+			"runAsync":   runAsync,
+			"volumeID":   volumeID,
+			"instanceID": instanceID}).Info("sdm.DetachVolume")
 		return d.DetachVolume(runAsync, volumeID, instanceID, force)
 	}
 	return errors.ErrNoStorageDetected
@@ -389,6 +444,11 @@ func (r *sdm) DetachVolume(
 func (r *sdm) GetVolumeAttach(
 	volumeID, instanceID string) ([]*VolumeAttachment, error) {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
+			"driverName": d.Name(),
+			"volumeID":   volumeID,
+			"instanceID": instanceID}).Info("sdm.GetVolumeAttach")
 		return d.GetVolumeAttach(volumeID, instanceID)
 	}
 	return nil, errors.ErrNoStorageDetected
@@ -399,6 +459,14 @@ func (r *sdm) CopySnapshot(
 	volumeID, snapshotID, snapshotName,
 	targetSnapshotName, targetRegion string) (*Snapshot, error) {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName":         r.rexray.Context,
+			"driverName":         d.Name(),
+			"runAsync":           runAsync,
+			"snapshotID":         snapshotID,
+			"snapshotName":       snapshotName,
+			"targetSnapshotName": targetSnapshotName,
+			"targetRegion":       targetRegion}).Info("sdm.CopySnapshot")
 		return d.CopySnapshot(runAsync, volumeID, snapshotID, snapshotName,
 			targetSnapshotName, targetRegion)
 	}
@@ -407,6 +475,9 @@ func (r *sdm) CopySnapshot(
 
 func (r *sdm) GetDeviceNextAvailable() (string, error) {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
+			"driverName": d.Name()}).Info("sdm.GetDeviceNextAvailable")
 		return d.GetDeviceNextAvailable()
 	}
 	return "", errors.ErrNoStorageDetected

--- a/core/drivers_volume.go
+++ b/core/drivers_volume.go
@@ -146,6 +146,7 @@ func (r *vdm) countUse(volumeName string) {
 	if c, ok := r.mapUsedCount[volumeName]; ok {
 		*c++
 		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
 			"volumeName": volumeName,
 			"count":      *c,
 		}).Info("set count to")
@@ -165,6 +166,7 @@ func (r *vdm) countInit(volumeName string) {
 	c = 0
 	r.mapUsedCount[volumeName] = &c
 	log.WithFields(log.Fields{
+		"moduleName": r.rexray.Context,
 		"volumeName": volumeName,
 		"count":      c,
 	}).Info("initialized count")
@@ -176,6 +178,7 @@ func (r *vdm) countRelease(volumeName string) {
 	if c, ok := r.mapUsedCount[volumeName]; ok {
 		*c--
 		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
 			"volumeName": volumeName,
 			"count":      *c,
 		}).Info("released count")
@@ -185,6 +188,7 @@ func (r *vdm) countRelease(volumeName string) {
 func (r *vdm) countExists(volumeName string) bool {
 	_, exists := r.mapUsedCount[volumeName]
 	log.WithFields(log.Fields{
+		"moduleName": r.rexray.Context,
 		"volumeName": volumeName,
 		"exists":     exists,
 	}).Info("status of count")
@@ -199,6 +203,7 @@ func (r *vdm) countReset(volumeName string) bool {
 	c, _ := r.mapUsedCount[volumeName]
 	if c != nil && *c < 2 {
 		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
 			"volumeName": volumeName,
 			"count":      *c,
 		}).Info("count reset")
@@ -215,6 +220,15 @@ func (r *vdm) Mount(
 	volumeName, volumeID string,
 	overwriteFs bool, newFsType string, preempt bool) (string, error) {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName":  r.rexray.Context,
+			"driverName":  d.Name(),
+			"volumeName":  volumeName,
+			"volumeID":    volumeID,
+			"overwriteFs": overwriteFs,
+			"newFsType":   newFsType,
+			"preempt":     preempt}).Info("vdm.Mount")
+
 		if !preempt {
 			preempt = r.preempt()
 		}
@@ -234,6 +248,12 @@ func (r *vdm) Mount(
 // Unmount will unmount the specified volume by volumeName or volumeID.
 func (r *vdm) Unmount(volumeName, volumeID string) error {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
+			"driverName": d.Name(),
+			"volumeName": volumeName,
+			"volumeID":   volumeID}).Info("vdm.Unmount")
+
 		if r.ignoreUsedCount() || r.countReset(volumeName) || !r.countExists(volumeName) {
 			r.countInit(volumeName)
 			return d.Unmount(volumeName, volumeID)
@@ -248,6 +268,12 @@ func (r *vdm) Unmount(volumeName, volumeID string) error {
 // Path will return the mounted path of the volumeName or volumeID.
 func (r *vdm) Path(volumeName, volumeID string) (string, error) {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
+			"driverName": d.Name(),
+			"volumeName": volumeName,
+			"volumeID":   volumeID}).Info("vdm.Path")
+
 		return d.Path(volumeName, volumeID)
 	}
 	return "", errors.ErrNoVolumesDetected
@@ -256,6 +282,11 @@ func (r *vdm) Path(volumeName, volumeID string) (string, error) {
 // Get will return a specific volume
 func (r *vdm) Get(volumeName string) (VolumeMap, error) {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
+			"driverName": d.Name(),
+			"volumeName": volumeName}).Info("vdm.Get")
+
 		return d.Get(volumeName)
 	}
 	return nil, errors.ErrNoVolumesDetected
@@ -264,6 +295,10 @@ func (r *vdm) Get(volumeName string) (VolumeMap, error) {
 // Get will return all volumes
 func (r *vdm) List() ([]VolumeMap, error) {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
+			"driverName": d.Name()}).Info("vdm.List")
+
 		return d.List()
 	}
 	return nil, errors.ErrNoVolumesDetected
@@ -272,6 +307,12 @@ func (r *vdm) List() ([]VolumeMap, error) {
 // Create will create a new volume with the volumeName and opts.
 func (r *vdm) Create(volumeName string, opts VolumeOpts) error {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
+			"driverName": d.Name(),
+			"volumeName": volumeName,
+			"opts":       opts}).Info("vdm.Create")
+
 		r.countInit(volumeName)
 		return d.Create(volumeName, opts)
 	}
@@ -281,6 +322,11 @@ func (r *vdm) Create(volumeName string, opts VolumeOpts) error {
 // Remove will remove a volume of volumeName.
 func (r *vdm) Remove(volumeName string) error {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
+			"driverName": d.Name(),
+			"volumeName": volumeName}).Info("vdm.Remove")
+
 		return d.Remove(volumeName)
 	}
 	return errors.ErrNoVolumesDetected
@@ -290,6 +336,13 @@ func (r *vdm) Remove(volumeName string) error {
 // instanceID.
 func (r *vdm) Attach(volumeName, instanceID string, force bool) (string, error) {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
+			"driverName": d.Name(),
+			"volumeName": volumeName,
+			"instanceID": instanceID,
+			"force":      force}).Info("vdm.Attach")
+
 		return d.Attach(volumeName, instanceID, force)
 	}
 	return "", errors.ErrNoVolumesDetected
@@ -299,6 +352,12 @@ func (r *vdm) Attach(volumeName, instanceID string, force bool) (string, error) 
 // instanceID.
 func (r *vdm) Detach(volumeName, instanceID string, force bool) error {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
+			"driverName": d.Name(),
+			"volumeName": volumeName,
+			"instanceID": instanceID,
+			"force":      force}).Info("vdm.Detach")
 		return d.Detach(volumeName, instanceID, force)
 	}
 	return errors.ErrNoVolumesDetected
@@ -309,6 +368,11 @@ func (r *vdm) Detach(volumeName, instanceID string, force bool) error {
 // local instanceID.
 func (r *vdm) NetworkName(volumeName, instanceID string) (string, error) {
 	for _, d := range r.drivers {
+		log.WithFields(log.Fields{
+			"moduleName": r.rexray.Context,
+			"driverName": d.Name(),
+			"volumeName": volumeName,
+			"instanceID": instanceID}).Info("vdm.NetworkName")
 		return d.NetworkName(volumeName, instanceID)
 	}
 	return "", errors.ErrNoVolumesDetected

--- a/core/rexray.go
+++ b/core/rexray.go
@@ -13,6 +13,7 @@ type RexRay struct {
 	OS      OSDriverManager
 	Volume  VolumeDriverManager
 	Storage StorageDriverManager
+	Context string
 	drivers map[string]Driver
 }
 

--- a/daemon/module/docker/volumedriver/voldriver.go
+++ b/daemon/module/docker/volumedriver/voldriver.go
@@ -56,8 +56,11 @@ func newModule(c *module.Config) (module.Module, error) {
 
 	c.Address = host
 
+	r := core.New(c.Config)
+	r.Context = c.Name
+
 	return &mod{
-		r:    core.New(c.Config),
+		r:    r,
 		name: c.Name,
 		desc: c.Description,
 		addr: host,

--- a/drivers/os/linux/linux.go
+++ b/drivers/os/linux/linux.go
@@ -36,8 +36,12 @@ func newDriver() core.Driver {
 func (d *driver) Init(r *core.RexRay) error {
 	if runtime.GOOS == "linux" {
 		d.r = r
-		log.WithField("provider", providerName).Info(
+
+		log.WithFields(log.Fields{
+			"moduleName": d.r.Context,
+			"provider":   providerName}).Info(
 			"os driver initialized")
+
 		return nil
 	}
 	return errors.ErrUnknownOS
@@ -147,6 +151,7 @@ func (d *driver) Format(
 	}
 
 	log.WithFields(log.Fields{
+		"moduleName":  d.r.Context,
 		"fsDetected":  fsDetected,
 		"fsType":      fsType,
 		"deviceName":  deviceName,

--- a/drivers/storage/openstack/openstack.go
+++ b/drivers/storage/openstack/openstack.go
@@ -72,17 +72,18 @@ func newDriver() core.Driver {
 
 func (d *driver) Init(r *core.RexRay) error {
 	d.r = r
-	fields := ef()
+	fields := eff(map[string]interface{}{})
 	var err error
 
-	if d.instanceID, err = getInstanceID(d.r.Config); err != nil {
+	if d.instanceID, err = d.getInstanceID(d.r.Config); err != nil {
 		return err
 	}
 
+	fields["moduleName"] = d.r.Context
 	fields["instanceId"] = d.instanceID
 
 	if d.regionName() == "" {
-		if d.region, err = getInstanceRegion(d.r.Config); err != nil {
+		if d.region, err = d.getInstanceRegion(d.r.Config); err != nil {
 			return err
 		}
 	} else {
@@ -136,7 +137,7 @@ func (d *driver) Init(r *core.RexRay) error {
 			"error getting newBlockStorageV2", err)
 	}
 
-	log.WithField("provider", providerName).Info("storage driver initialized")
+	log.WithFields(fields).Info("storage driver initialized")
 
 	return nil
 }
@@ -155,16 +156,17 @@ func newCmd(c gofig.Config, name string, args ...string) *exec.Cmd {
 	return cmd
 }
 
-func getInstanceID(c gofig.Config) (string, error) {
+func (d *driver) getInstanceID(c gofig.Config) (string, error) {
 	cmd := newCmd(c, "/usr/sbin/dmidecode")
 	cmdOut, err := cmd.Output()
 
 	if err != nil {
 		return "",
 			goof.WithFields(eff(goof.Fields{
-				"cmd.Path": cmd.Path,
-				"cmd.Args": cmd.Args,
-				"cmd.Out":  cmdOut,
+				"moduleName": d.r.Context,
+				"cmd.Path":   cmd.Path,
+				"cmd.Args":   cmd.Args,
+				"cmd.Out":    cmdOut,
 			}), "error getting instance id")
 	}
 
@@ -192,7 +194,9 @@ func (d *driver) getInstance() (*servers.Server, error) {
 	server, err := servers.Get(d.client, d.instanceID).Extract()
 	if err != nil {
 		return nil,
-			goof.WithFieldsE(ef(), "error getting server instance", err)
+			goof.WithFieldsE(eff(map[string]interface{}{
+				"moduleName": d.r.Context,
+			}), "error getting server instance", err)
 	}
 
 	return server, nil
@@ -202,7 +206,9 @@ func (d *driver) GetInstance() (*core.Instance, error) {
 	server, err := d.getInstance()
 	if err != nil {
 		return nil,
-			goof.WithFieldsE(ef(), "error getting driver instance", err)
+			goof.WithFieldsE(eff(map[string]interface{}{
+				"moduleName": d.r.Context,
+			}), "error getting driver instance", err)
 	}
 
 	instance := &core.Instance{
@@ -220,6 +226,7 @@ func (d *driver) GetVolumeMapping() ([]*core.BlockDevice, error) {
 	if err != nil {
 		return nil,
 			goof.WithFieldsE(eff(goof.Fields{
+				"moduleName": d.r.Context,
 				"instanceId": d.instanceID,
 			}), "error getting block devices", err)
 	}
@@ -252,6 +259,7 @@ func (d *driver) getBlockDevices(
 	if err != nil {
 		return []volumeattach.VolumeAttachment{},
 			goof.WithFieldsE(eff(goof.Fields{
+				"moduleName": d.r.Context,
 				"instanceId": instanceID}),
 				"error extracting volume attachments", err)
 	}
@@ -260,7 +268,7 @@ func (d *driver) getBlockDevices(
 
 }
 
-func getInstanceRegion(cfg gofig.Config) (string, error) {
+func (d *driver) getInstanceRegion(cfg gofig.Config) (string, error) {
 	cmd := newCmd(
 		cfg, "/usr/bin/xenstore-read",
 		"vm-data/provider_data/region")
@@ -269,9 +277,10 @@ func getInstanceRegion(cfg gofig.Config) (string, error) {
 	if err != nil {
 		return "",
 			goof.WithFields(eff(goof.Fields{
-				"cmd.Path": cmd.Path,
-				"cmd.Args": cmd.Args,
-				"cmd.Out":  cmdOut,
+				"moduleName": d.r.Context,
+				"cmd.Path":   cmd.Path,
+				"cmd.Args":   cmd.Args,
+				"cmd.Out":    cmdOut,
 			}), "error getting instance region")
 	}
 
@@ -305,14 +314,16 @@ func getInstanceAvailabilityZone() (string, error) {
 func (d *driver) getVolume(
 	volumeID, volumeName string) (volumesRet []volumes.Volume, err error) {
 
+	fields := eff(goof.Fields{
+		"moduleName": d.r.Context,
+		"volumeId":   volumeID,
+		"volumeName": volumeName})
+
 	if volumeID != "" {
 		volume, err := volumes.Get(d.clientBlockStorage, volumeID).Extract()
 		if err != nil {
 			return []volumes.Volume{},
-				goof.WithFieldsE(eff(goof.Fields{
-					"volumeId":   volumeID,
-					"volumeName": volumeName}),
-					"error getting volumes", err)
+				goof.WithFieldsE(fields, "error getting volumes", err)
 		}
 		volumesRet = append(volumesRet, *volume)
 	} else {
@@ -323,18 +334,12 @@ func (d *driver) getVolume(
 		allPages, err := volumes.List(d.clientBlockStorage, listOpts).AllPages()
 		if err != nil {
 			return []volumes.Volume{},
-				goof.WithFieldsE(eff(goof.Fields{
-					"volumeId":   volumeID,
-					"volumeName": volumeName}),
-					"error listing volumes", err)
+				goof.WithFieldsE(fields, "error listing volumes", err)
 		}
 		volumesRet, err = volumes.ExtractVolumes(allPages)
 		if err != nil {
 			return []volumes.Volume{},
-				goof.WithFieldsE(eff(goof.Fields{
-					"volumeId":   volumeID,
-					"volumeName": volumeName}),
-					"error extracting volumes", err)
+				goof.WithFieldsE(fields, "error extracting volumes", err)
 		}
 
 		var volumesRetFiltered []volumes.Volume
@@ -364,6 +369,7 @@ func (d *driver) GetVolume(
 	if err != nil {
 		return []*core.Volume{},
 			goof.WithFieldsE(eff(goof.Fields{
+				"moduleName": d.r.Context,
 				"volumeId":   volumeID,
 				"volumeName": volumeName}),
 				"error getting volume", err)
@@ -402,6 +408,7 @@ func (d *driver) GetVolumeAttach(
 	volumeID, instanceID string) ([]*core.VolumeAttachment, error) {
 
 	fields := eff(map[string]interface{}{
+		"moduleName": d.r.Context,
 		"volumeId":   volumeID,
 		"instanceId": instanceID,
 	})
@@ -436,6 +443,7 @@ func (d *driver) getSnapshot(
 	snapshotName string) (allSnapshots []snapshots.Snapshot, err error) {
 
 	fields := eff(map[string]interface{}{
+		"moduleName":   d.r.Context,
 		"volumeId":     volumeID,
 		"snapshotId":   snapshotID,
 		"snapshotName": snapshotName,
@@ -478,6 +486,7 @@ func (d *driver) GetSnapshot(
 	if err != nil {
 		return nil,
 			goof.WithFieldsE(eff(goof.Fields{
+				"moduleName":   d.r.Context,
 				"volumeId":     volumeID,
 				"snapshotId":   snapshotID,
 				"snapshotName": snapshotName}),
@@ -506,6 +515,7 @@ func (d *driver) CreateSnapshot(
 	snapshotName, volumeID, description string) ([]*core.Snapshot, error) {
 
 	fields := eff(map[string]interface{}{
+		"moduleName":   d.r.Context,
 		"runAsync":     runAsync,
 		"snapshotName": snapshotName,
 		"volumeId":     volumeID,
@@ -526,7 +536,8 @@ func (d *driver) CreateSnapshot(
 	}
 
 	if !runAsync {
-		log.Debug("waiting for snapshot creation to complete")
+		log.WithFields(fields).Info("waiting for volume creation to complete")
+
 		err = snapshots.WaitForStatus(d.clientBlockStorage, resp.ID, "available", 120)
 		if err != nil {
 			return nil,
@@ -540,12 +551,6 @@ func (d *driver) CreateSnapshot(
 		return nil, err
 	}
 
-	log.WithFields(log.Fields{
-		"runAsync":     runAsync,
-		"snapshotName": snapshotName,
-		"volumeId":     volumeID,
-		"description":  description}).Debug("created snapshot")
-
 	return snapshot, nil
 
 }
@@ -553,11 +558,10 @@ func (d *driver) CreateSnapshot(
 func (d *driver) RemoveSnapshot(snapshotID string) error {
 	resp := snapshots.Delete(d.clientBlockStorage, snapshotID)
 	if resp.Err != nil {
-		return goof.WithFieldE(
-			"snapshotId", snapshotID, "error removing snapshot", resp.Err)
+		return goof.WithFieldsE(goof.Fields{
+			"moduleName": d.r.Context,
+			"snapshotId": snapshotID}, "error removing snapshot", resp.Err)
 	}
-
-	log.WithField("snapshotId", snapshotID).Debug("removed snapshot")
 
 	return nil
 }
@@ -573,6 +577,7 @@ func (d *driver) CreateVolume(
 	availabilityZone string) (*core.Volume, error) {
 
 	fields := map[string]interface{}{
+		"moduleName":       d.r.Context,
 		"provider":         providerName,
 		"runAsync":         runAsync,
 		"volumeName":       volumeName,
@@ -619,7 +624,7 @@ func (d *driver) CreateVolume(
 	}
 
 	if !runAsync {
-		log.Debug("waiting for volume creation to complete")
+		log.WithFields(fields).Info("waiting for volume creation to complete")
 		err = volumes.WaitForStatus(d.clientBlockStorage, resp.ID, "available", 120)
 		if err != nil {
 			return nil,
@@ -646,7 +651,6 @@ func (d *driver) CreateVolume(
 			"error removing snapshot")
 	}
 
-	log.WithFields(fields).Debug("created volume")
 	return volume[0], nil
 }
 
@@ -744,7 +748,8 @@ func (d *driver) createVolumeHandleVolumeID(
 
 func (d *driver) RemoveVolume(volumeID string) error {
 	fields := eff(map[string]interface{}{
-		"volumeId": volumeID,
+		"moduleName": d.r.Context,
+		"volumeId":   volumeID,
 	})
 	if volumeID == "" {
 		return goof.WithFields(fields, "volumeId is required")
@@ -754,7 +759,6 @@ func (d *driver) RemoveVolume(volumeID string) error {
 		return goof.WithFieldsE(fields, "error removing volume", res.Err)
 	}
 
-	log.WithFields(fields).Debug("removed volume")
 	return nil
 }
 
@@ -823,6 +827,7 @@ func (d *driver) AttachVolume(
 	runAsync bool, volumeID, instanceID string, force bool) ([]*core.VolumeAttachment, error) {
 
 	fields := eff(map[string]interface{}{
+		"moduleName": d.r.Context,
 		"runAsync":   runAsync,
 		"volumeId":   volumeID,
 		"instanceId": instanceID,
@@ -865,7 +870,6 @@ func (d *driver) AttachVolume(
 		return nil, err
 	}
 
-	log.WithFields(fields).Debug("volume attached")
 	return volumeAttachment, nil
 }
 
@@ -873,6 +877,7 @@ func (d *driver) DetachVolume(
 	runAsync bool, volumeID, instanceID string, force bool) error {
 
 	fields := eff(map[string]interface{}{
+		"moduleName": d.r.Context,
 		"runAsync":   runAsync,
 		"volumeId":   volumeID,
 		"instanceId": instanceID,
@@ -916,14 +921,14 @@ func (d *driver) DetachVolume(
 		}
 	}
 
-	log.WithFields(fields).Debug("volume detached")
 	return nil
 }
 
 func (d *driver) waitVolumeAttach(volumeID string) error {
 
 	fields := eff(map[string]interface{}{
-		"volumeId": volumeID,
+		"moduleName": d.r.Context,
+		"volumeId":   volumeID,
 	})
 
 	if volumeID == "" {
@@ -946,7 +951,8 @@ func (d *driver) waitVolumeAttach(volumeID string) error {
 func (d *driver) waitVolumeDetach(volumeID string) error {
 
 	fields := eff(map[string]interface{}{
-		"volumeId": volumeID,
+		"moduleName": d.r.Context,
+		"volumeId":   volumeID,
 	})
 
 	if volumeID == "" {

--- a/drivers/storage/vmax/vmax.go
+++ b/drivers/storage/vmax/vmax.go
@@ -69,11 +69,12 @@ func (d *driver) Init(r *core.RexRay) error {
 	d.r = r
 
 	fields := eff(map[string]interface{}{
-		"userName": d.userName(),
-		"smisHost": d.smisHost(),
-		"smisPort": d.smisPort(),
-		"insecure": d.insecure(),
-		"sid":      d.sid(),
+		"moduleName": d.r.Context,
+		"userName":   d.userName(),
+		"smisHost":   d.smisHost(),
+		"smisPort":   d.smisPort(),
+		"insecure":   d.insecure(),
+		"sid":        d.sid(),
 	})
 
 	if d.password() == "" {
@@ -97,9 +98,10 @@ func (d *driver) Init(r *core.RexRay) error {
 	d.volPrefix = d.volumePrefix()
 
 	vmFields := eff(map[string]interface{}{
-		"userName": d.vmhUserName(),
-		"smisHost": d.vmhHost(),
-		"insecure": d.vmhInsecure(),
+		"moduleName": d.r.Context,
+		"userName":   d.vmhUserName(),
+		"smisHost":   d.vmhHost(),
+		"insecure":   d.vmhInsecure(),
 	})
 
 	if d.vmh, err = govmax.NewVMHost(
@@ -114,7 +116,7 @@ func (d *driver) Init(r *core.RexRay) error {
 
 	d.instanceID = d.vmh.Vm.Reference().Value
 
-	log.WithField("provider", providerName).Info("storage driver initialized")
+	log.WithFields(fields).Info("storage driver initialized")
 
 	return nil
 }
@@ -363,7 +365,8 @@ func (d *driver) CreateVolume(
 
 func (d *driver) RemoveVolume(volumeID string) error {
 	fields := eff(map[string]interface{}{
-		"volumeID": volumeID,
+		"moduleName": d.r.Context,
+		"volumeID":   volumeID,
 	})
 
 	deleteVolumeRequest := &govmax.DeleteVolReq{
@@ -392,7 +395,6 @@ func (d *driver) RemoveVolume(volumeID string) error {
 		return err
 	}
 
-	log.Println("Deleted Volume: " + volumeID)
 	return nil
 }
 
@@ -588,7 +590,9 @@ func (d *driver) AttachVolume(
 		return nil, goof.New("local device not found for volume")
 	}
 
-	log.WithFields(log.Fields{"deviceName": deviceName}).Println("discovered device")
+	log.WithFields(log.Fields{
+		"moduleName": d.r.Context,
+		"deviceName": deviceName}).Info("discovered device")
 
 	volumeAttachment, err := d.GetVolumeAttach(volumeID, instanceID)
 	if err != nil {
@@ -688,7 +692,6 @@ func (d *driver) DetachVolume(runAsync bool, volumeID string, blank string, notu
 		return goof.WithError("error detaching volume from storage group", err)
 	}
 
-	log.Println("Detached volume", volumeID)
 	return nil
 }
 

--- a/drivers/storage/xtremio/xtremio.go
+++ b/drivers/storage/xtremio/xtremio.go
@@ -69,6 +69,7 @@ func (d *driver) Init(r *core.RexRay) error {
 	d.volumesByNaa = map[string]xtio.Volume{}
 
 	fields := eff(map[string]interface{}{
+		"moduleName":       d.r.Context,
 		"endpoint":         d.endpoint(),
 		"userName":         d.userName(),
 		"deviceMapper":     d.deviceMapper(),
@@ -110,7 +111,7 @@ func (d *driver) Init(r *core.RexRay) error {
 		}
 	}
 
-	log.WithField("provider", providerName).Info("storage driver initialized")
+	log.WithFields(fields).Info("storage driver initialized")
 
 	return nil
 }
@@ -410,6 +411,7 @@ func (d *driver) GetVolumeMapping() ([]*core.BlockDevice, error) {
 
 func (d *driver) getVolume(volumeID, volumeName string) ([]xtio.Volume, error) {
 	fields := eff(map[string]interface{}{
+		"moduleName": d.r.Context,
 		"volumeID":   volumeID,
 		"volumeName": volumeName,
 	})
@@ -511,6 +513,7 @@ func (d *driver) CreateVolume(
 	NUIOPS, size int64, NUavailabilityZone string) (*core.Volume, error) {
 
 	fields := eff(map[string]interface{}{
+		"moduleName": d.r.Context,
 		"volumeID":   volumeID,
 		"volumeName": volumeName,
 		"snapshotID": snapshotID,
@@ -564,7 +567,8 @@ func (d *driver) CreateVolume(
 
 func (d *driver) RemoveVolume(volumeID string) error {
 	fields := eff(map[string]interface{}{
-		"volumeID": volumeID,
+		"moduleName": d.r.Context,
+		"volumeID":   volumeID,
 	})
 
 	err := d.client.DeleteVolume(volumeID, "")
@@ -572,7 +576,6 @@ func (d *driver) RemoveVolume(volumeID string) error {
 		return goof.WithFieldsE(fields, "error deleting volume", err)
 	}
 
-	log.Println("Deleted Volume: " + volumeID)
 	return nil
 }
 
@@ -945,7 +948,6 @@ func (d *driver) DetachVolume(notUsed bool, volumeID string, blank string, notus
 		}
 	}
 
-	log.Println("Detached volume", volumeID)
 	return nil
 }
 

--- a/drivers/volume/docker/volume.go
+++ b/drivers/volume/docker/volume.go
@@ -61,6 +61,7 @@ func (d *driver) Init(r *core.RexRay) error {
 	d.r = r
 
 	fields := eff(map[string]interface{}{
+		"moduleName":       d.r.Context,
 		"volumeType":       d.volumeType(),
 		"iops":             d.iops(),
 		"size":             d.size(),
@@ -386,6 +387,7 @@ func (d *driver) Create(volumeName string, volumeOpts core.VolumeOpts) error {
 		_, err = d.Mount(volumeName, "", overwriteFs, newFsType, false)
 		if err != nil {
 			log.WithFields(log.Fields{
+				"moduleName":  d.r.Context,
 				"volumeName":  volumeName,
 				"overwriteFs": overwriteFs,
 				"newFsType":   newFsType,

--- a/drivers/volume/docker/volume.go
+++ b/drivers/volume/docker/volume.go
@@ -90,6 +90,7 @@ func (d *driver) Name() string {
 // Mount will perform the steps to get an existing Volume with or without a fileystem mounted to a guest
 func (d *driver) Mount(volumeName, volumeID string, overwriteFs bool, newFsType string, preempt bool) (string, error) {
 	log.WithFields(log.Fields{
+		"moduleName":  d.r.Context,
 		"volumeName":  volumeName,
 		"volumeID":    volumeID,
 		"overwriteFs": overwriteFs,
@@ -172,6 +173,7 @@ func (d *driver) Mount(volumeName, volumeID string, overwriteFs bool, newFsType 
 func (d *driver) Unmount(volumeName, volumeID string) error {
 
 	log.WithFields(log.Fields{
+		"moduleName": d.r.Context,
 		"volumeName": volumeName,
 		"volumeID":   volumeID,
 		"driverName": d.Name()}).Info("unmounting volume")
@@ -262,6 +264,7 @@ func (d *driver) prefixToMountUnmount(
 // Path returns the mounted path of the volume
 func (d *driver) Path(volumeName, volumeID string) (string, error) {
 	log.WithFields(log.Fields{
+		"moduleName": d.r.Context,
 		"volumeName": volumeName,
 		"volumeID":   volumeID,
 		"driverName": d.Name()}).Info("getting path to volume")
@@ -317,6 +320,7 @@ func (d *driver) Path(volumeName, volumeID string) (string, error) {
 // Create will create a remote volume
 func (d *driver) Create(volumeName string, volumeOpts core.VolumeOpts) error {
 	log.WithFields(log.Fields{
+		"moduleName": d.r.Context,
 		"volumeName": volumeName,
 		"volumeOpts": volumeOpts,
 		"driverName": d.Name()}).Info("creating volume")
@@ -588,6 +592,7 @@ func (d *driver) createInitString(optKey, envVar string,
 // Remove will remove a remote volume
 func (d *driver) Remove(volumeName string) error {
 	log.WithFields(log.Fields{
+		"moduleName": d.r.Context,
 		"volumeName": volumeName,
 		"driverName": d.Name()}).Info("removing volume")
 
@@ -634,6 +639,7 @@ func (d *driver) Remove(volumeName string) error {
 
 func (d *driver) Get(volumeName string) (core.VolumeMap, error) {
 	log.WithFields(log.Fields{
+		"moduleName": d.r.Context,
 		"volumeName": volumeName,
 		"driverName": d.Name()}).Info("getting volume")
 
@@ -736,6 +742,7 @@ Volumes:
 // List will list all volumes
 func (d *driver) List() ([]core.VolumeMap, error) {
 	log.WithFields(log.Fields{
+		"moduleName": d.r.Context,
 		"driverName": d.Name()}).Info("listing volumes")
 
 	return d.get("")
@@ -744,6 +751,7 @@ func (d *driver) List() ([]core.VolumeMap, error) {
 // Attach will attach a volume to an instance
 func (d *driver) Attach(volumeName, instanceID string, force bool) (string, error) {
 	log.WithFields(log.Fields{
+		"moduleName": d.r.Context,
 		"volumeName": volumeName,
 		"instanceID": instanceID,
 		"driverName": d.Name()}).Info("attaching volume")
@@ -776,6 +784,7 @@ func (d *driver) Attach(volumeName, instanceID string, force bool) (string, erro
 // Remove will remove a remote volume
 func (d *driver) Detach(volumeName, instanceID string, force bool) error {
 	log.WithFields(log.Fields{
+		"moduleName": d.r.Context,
 		"volumeName": volumeName,
 		"instanceID": instanceID,
 		"driverName": d.Name()}).Info("detaching volume")
@@ -791,6 +800,7 @@ func (d *driver) Detach(volumeName, instanceID string, force bool) error {
 // NetworkName will return relevant information about how a volume can be discovered on an OS
 func (d *driver) NetworkName(volumeName, instanceID string) (string, error) {
 	log.WithFields(log.Fields{
+		"moduleName": d.r.Context,
 		"volumeName": volumeName,
 		"instanceID": instanceID,
 		"driverName": d.Name()}).Info("returning network name")


### PR DESCRIPTION
This patch adds the field `Context` to the REX-Ray struct, enabling modules to set the context for a REX-Ray runtime for future logging.

This PR handles issue #295.