### PR TITLE
Fixed ScaleIO re-authentication problem with multiple instances

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -20,7 +20,7 @@ import:
     repo:    https://github.com/clintonskitson/goamz
     vcs:     git
   - package: github.com/emccode/goscaleio
-    ref:     29678665e99b627013b8b9f2727bbdaed79bbd05
+    ref:     37a71bf801a533473f94e4d4dcee2372c141e261
     repo:    https://github.com/emccode/goscaleio.git
     vcs:     git
   - package: github.com/emccode/goxtremio


### PR DESCRIPTION
This commit introduces an updated goscaleio package that fixes
a problem where with multiple SIO instances configured, the
re-authentication process when tokens expired would fail.