### PR TITLE
Added limitation for volume name for SIO

### DIFF
--- a/drivers/storage/scaleio/scaleio.go
+++ b/drivers/storage/scaleio/scaleio.go
@@ -16,6 +16,7 @@ import (
 )
 
 const providerName = "ScaleIO"
+const cc = 31
 
 // The ScaleIO storage driver.
 type driver struct {
@@ -197,8 +198,18 @@ func (d *driver) GetVolumeMapping() ([]*core.BlockDevice, error) {
 	return BlockDevices, nil
 }
 
+func shrink(n string) string {
+	if len(n) > cc {
+		return n[:cc]
+	}
+	return n
+}
+
 func (d *driver) getVolume(
 	volumeID, volumeName string, getSnapshots bool) ([]*types.Volume, error) {
+
+	volumeName = shrink(volumeName)
+
 	volumes, err := d.client.GetVolume("", volumeID, "", volumeName, getSnapshots)
 	if err != nil {
 		return nil, err
@@ -448,6 +459,8 @@ func (d *driver) createVolume(
 	notUsed bool,
 	volumeName, volumeID, snapshotID, volumeType string,
 	IOPS, size int64, availabilityZone string) (*types.VolumeResp, error) {
+
+	volumeName = shrink(volumeName)
 
 	fields := eff(map[string]interface{}{
 		"volumeID":         volumeID,


### PR DESCRIPTION
This commit introduces a new volume name limit that pertains
specifically to the SIO storage platform. The limit is 31 chars
enforced by SIO. A bug was introduced by Docker 1.10 since it
started creating anonymous volumes when no volumes were specified
which defaulted to 32 characters.