### PR TITLE
Docker cache volumes for path operations

### DIFF
--- a/.docs/user-guide/config.md
+++ b/.docs/user-guide/config.md
@@ -744,7 +744,23 @@ sharing volumes, it is recommended that you reset the service along with the
 accompanying container runtime (if this setting is false) to ensure they are
 synchronized.  
 
-#### Volume Path (0.3.1)
+#### Volume Path Disable Cache (0.3.2)
+In order to minimize the impact to return `Path` requests, a caching
+capability has been introduced by default. A `List` request will cause the
+returned volumes and paths to be evaluated and those with active mounts are
+recorded. Subsequent `Path` requests for volumes that have no recorded mounts
+will not result in active path lookups. Once the mount counter is initialized or
+a `List` operation occurs where a mount is recorded, the volume will be looked
+up for future `Path` operations.
+
+```yaml
+rexray:
+  volume:
+    path:
+      disableCache: true
+```
+
+#### Volume Root Path (0.3.1)
 When volumes are mounted there can be an additional path that is specified to
 be created and passed as the valid mount point.  This is required for certain
 applications that do not want to place data from the root of a mount point.  

--- a/daemon/module/docker/volumedriver/voldriver.go
+++ b/daemon/module/docker/volumedriver/voldriver.go
@@ -56,7 +56,16 @@ func newModule(c *module.Config) (module.Module, error) {
 
 	c.Address = host
 
-	r := core.New(c.Config)
+	cc, err := c.Config.Copy()
+	if err != nil {
+		return nil, err
+	}
+
+	if !cc.GetBool("rexray.volume.path.disableCache") {
+		cc.Set("rexray.volume.path.cache", true)
+	}
+
+	r := core.New(cc)
 	r.Context = c.Name
 
 	return &mod{

--- a/drivers/volume/docker/volume.go
+++ b/drivers/volume/docker/volume.go
@@ -688,6 +688,11 @@ func (d *driver) get(volumeName string) ([]core.VolumeMap, error) {
 
 	var volList []core.VolumeMap
 
+	allMounts, err := d.r.OS.GetMounts("", "")
+	if err != nil {
+		return nil, err
+	}
+
 Volumes:
 	for _, volume := range volumes {
 		if len(volume.Attachments) == 0 {
@@ -711,11 +716,6 @@ Volumes:
 				"Name": volume.Name,
 			})
 			continue Volumes
-		}
-
-		allMounts, err := d.r.OS.GetMounts("", "")
-		if err != nil {
-			return nil, err
 		}
 
 		var mounts []*mount.Info


### PR DESCRIPTION
This introduces a volume caching feature for Path lookups. Any Path operations will only result in a future lookup if a volume 1) is mounted when rr started 2) mount operation occurs on it. This addresses a Docker 1.10.1 problem issue where Path requests are made across every volume that has not Mountpoint listed from List requests.

This should be rebased after https://github.com/emccode/rexray/pull/296 is merged.  No conflicts should exist at that point.