### PR TITLE
Go 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.5.1
+  - 1.6
 
 addons:
   apt:


### PR DESCRIPTION
This feature changes the Travis-CI file to instruct Travis to build REX-Ray using Go 1.6.