### PR TITLE
Glide 0.9 Resolve Current Fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ _deps:
 			$(PRINT_STATUS); \
 		printf "  ...glide up..."; \
 			cd $(BASEDIR); \
-			$(GLIDE) up $(MAKE_LOG_FD); \
+			$(GLIDE) up --resolve-current $(MAKE_LOG_FD); \
 			$(PRINT_STATUS); \
 		printf "  ...go get..."; \
 			go get -d $(GOFLAGS) $(NV); \


### PR DESCRIPTION
This patch fixes an issue with Glide 0.9 causing an error when it attempts to resolve dependencies across multiple Go OS/Arch combinations.