### PR TITLE
Added ec2 tags to volumes and snapshots

### DIFF
--- a/.docs/user-guide/storage-providers.md
+++ b/.docs/user-guide/storage-providers.md
@@ -43,6 +43,20 @@ aws:
     accessKey: MyAccessKey
     secretKey: MySecretKey
 ```
+### Volume tagging (optional)
+
+By default, Rexray has access to all volumes and snapshots defined in Amazon account. Though sometimes it can be useful. it can be also overwhelming. Therefore, Rexray has an optional `rexrayTag` key in `aws` section to limit its view. When it is present, all volumes and snapshots created will have an additional EC2 tag `rexraySet` with a value defined in config. That way it not only limits Rexray view, but also makes possible to have different environments, like `prod`, `testing` or `development` each with its own set of volumes/snapshots.
+
+It can be defined like that:
+```yaml
+rexray:
+  storageDrivers:
+  - ec2
+aws:
+    accessKey: MyAccessKey
+    secretKey: MySecretKey
+    rexrayTag: prod
+```
 
 ## Google Compute Engine
 The Google Compute Engine (GCE) registers a storage driver named `gce` with the
@@ -327,7 +341,7 @@ parameter.
 - By default the password is the same as your administrative MDM password.
 - Start the gateway `service scaleio-gateway start`.
  - With 1.32 we have noticed a restart of the gateway may be necessary as well
-after an initial install with `service scaleio-gateway restart`. 
+after an initial install with `service scaleio-gateway restart`.
 
 ### Activating the Driver
 To activate the ScaleIO driver please follow the instructions for


### PR DESCRIPTION
Now rexray only lists volumes and snapshot with specific tag/value.
Tag is defined in `drivers/storage/ec2.go` driver:
```
const rexrayTag = "rexraySet»
```
Tag value can be defined in `rexray/config.yml`:
```
aws:
  accessKey: ...
  secretKey: ...
  region: ...
  rexrayTag: rexray
```
Default value is `rexray`.
