### PR TITLE
Release Candidate 0.3.2-RC4

### DIFF
--- a/.docs/about/release-notes.md
+++ b/.docs/about/release-notes.md
@@ -42,7 +42,7 @@ You can determine your currently installed version using `rexray version`:
 * Service status is reported correctly ([#310](https://github.com/emccode/rexray/pull/310))
 
 ### Updates
-* Go 1.6 ([#308](https://github.com/emccode/rexray/pull/308))
+* ~~Go 1.6 ([#308](https://github.com/emccode/rexray/pull/308))~~
 
 ### Thank You
 * Dan Forrest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.6
+  - 1.5.1
 
 addons:
   apt:


### PR DESCRIPTION
This patch marks the release of 0.3.2-RC4, a necessary RC in order to downgrade the Golang dependency from 1.6 back to 1.5.1 due to a compatibility issue with versions of Docker older than 1.10 (#317). Golang 1.6 will be reevaluated as a dependency of REX-Ray in its next minor release, 0.4.