### PR TITLE
Fix for no logging in 0.3.2-RC3/RC4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+go_import_path: github.com/emccode/rexray
+
 language: go
 
 go:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,9 @@
 package: github.com/emccode/rexray
 import:
+  - package: github.com/Sirupsen/logrus
+    ref:     feature/logrus-aware-types
+    repo:    https://github.com/akutz/logrus
+    vcs:     git
   - package: github.com/akutz/goof
     ref:     master
     vcs:     git


### PR DESCRIPTION
This patch should fix the issue of no logging in 0.3.2-RC3/RC4 built on Travis. The error was due to the way Glide changed transitive dependency discovery and was no longer using the Logrus package referenced by REX-Ray's referenced Goof package. The correct Logrus package is now explicitly listed in the REX-Ray glide.yaml file.