### PR TITLE
Bugfix for volumetype as mount fs

### DIFF
--- a/drivers/volume/docker/volume.go
+++ b/drivers/volume/docker/volume.go
@@ -142,8 +142,8 @@ func (d *driver) Mount(volumeName, volumeID string, overwriteFs bool, newFsType 
 	}
 
 	switch {
-	case d.volumeType() != "":
-		newFsType = d.volumeType()
+	case d.fsType() != "":
+		newFsType = d.fsType()
 	case newFsType == "":
 		newFsType = "ext4"
 	}
@@ -861,8 +861,13 @@ func (d *driver) availabilityZone() string {
 	return d.r.Config.GetString("docker.availabilityZone")
 }
 
+func (d *driver) fsType() string {
+	return d.r.Config.GetString("docker.fsType")
+}
+
 func configRegistration() *gofig.Registration {
 	r := gofig.NewRegistration("Docker")
+	r.Key(gofig.String, "", "", "", "docker.fsType")
 	r.Key(gofig.String, "", "", "", "docker.volumeType")
 	r.Key(gofig.String, "", "", "", "docker.iops")
 	r.Key(gofig.String, "", "", "", "docker.size")


### PR DESCRIPTION
This commit fixes the situation where when specifying a
volumeType as a global parameter for Docker, the mount operation
attempts to use that for the fileSystem. The fsType is now
a configurable item as well.