### PR TITLE
Fixed no volumes returned on empty list

### DIFF
--- a/daemon/module/docker/volumedriver/voldriver.go
+++ b/daemon/module/docker/volumedriver/voldriver.go
@@ -349,14 +349,14 @@ func (m *mod) buildMux() *http.ServeMux {
 		var pr pluginRequest
 		if err := json.NewDecoder(r.Body).Decode(&pr); err != nil {
 			http.Error(w, fmt.Sprintf("{\"Error\":\"%s\"}", err.Error()), 500)
-			log.WithField("error", err).Error("/VolumeDriver.Path: error decoding json")
+			log.WithField("error", err).Error("/VolumeDriver.List: error decoding json")
 			return
 		}
 
 		volList, err := m.r.Volume.List()
 		if err != nil {
 			http.Error(w, fmt.Sprintf("{\"Error\":\"%s\"}", err.Error()), 500)
-			log.WithField("error", err.Error()).Error("/VolumeDriver.Get: error listing volumes")
+			log.WithField("error", err.Error()).Error("/VolumeDriver.List: error listing volumes")
 			log.Error(err)
 			return
 		}

--- a/drivers/volume/docker/volume.go
+++ b/drivers/volume/docker/volume.go
@@ -680,6 +680,8 @@ func (d *driver) get(volumeName string) ([]core.VolumeMap, error) {
 	}
 
 	switch {
+	case len(volumes) == 0 && volumeName == "":
+		return nil, nil
 	case len(volumes) == 0:
 		return nil, goof.New("No volumes returned")
 	case len(volumes) > 1 && volumeName != "":


### PR DESCRIPTION
This commit fixes an error that was being returned to Docker when
there were no volumes returned from a list operation.