### PR TITLE
Added a disable feature for create/remove volume

### DIFF
--- a/.docs/user-guide/config.md
+++ b/.docs/user-guide/config.md
@@ -682,6 +682,30 @@ The above example disables the `default-docker` and `isilon3` modules such that
 This section describes various global configuration options related to
 operations such as mounting and unmounting volumes.
 
+#### Disable Create
+The disable create feature enables you to disallow any volume creation activity.
+Any requests will be returned in a successful manner, but the create will not
+get passed to the backend storage platform.
+
+```yaml
+rexray:
+  volume:
+    create:
+      disable: true
+```
+
+#### Disable Remove
+The disable remove feature enables you to disallow any volume removal activity.
+Any requests will be returned in a successful manner, but the remove will not
+get passed to the backend storage platform.
+
+```yaml
+rexray:
+  volume:
+    remove:
+      disable: true
+```
+
 #### Preemption
 There is a capability to preemptively detach any existing attachments to other
 instances before attempting a mount.  This will enable use cases for

--- a/core/drivers_volume.go
+++ b/core/drivers_volume.go
@@ -369,10 +369,15 @@ func (r *vdm) List() ([]VolumeMap, error) {
 func (r *vdm) Create(volumeName string, opts VolumeOpts) error {
 	for _, d := range r.drivers {
 		log.WithFields(log.Fields{
-			"moduleName": r.rexray.Context,
-			"driverName": d.Name(),
-			"volumeName": volumeName,
-			"opts":       opts}).Info("vdm.Create")
+			"moduleName":    r.rexray.Context,
+			"driverName":    d.Name(),
+			"volumeName":    volumeName,
+			"opts":          opts,
+			"disableCreate": r.disableCreate()}).Info("vdm.Create")
+
+		if r.disableCreate() {
+			return nil
+		}
 
 		r.countInit(volumeName)
 		return d.Create(volumeName, opts)
@@ -384,9 +389,14 @@ func (r *vdm) Create(volumeName string, opts VolumeOpts) error {
 func (r *vdm) Remove(volumeName string) error {
 	for _, d := range r.drivers {
 		log.WithFields(log.Fields{
-			"moduleName": r.rexray.Context,
-			"driverName": d.Name(),
-			"volumeName": volumeName}).Info("vdm.Remove")
+			"moduleName":    r.rexray.Context,
+			"driverName":    d.Name(),
+			"volumeName":    volumeName,
+			"disableRemove": r.disableRemove()}).Info("vdm.Remove")
+
+		if r.disableRemove() {
+			return nil
+		}
 
 		return d.Remove(volumeName)
 	}
@@ -441,6 +451,14 @@ func (r *vdm) NetworkName(volumeName, instanceID string) (string, error) {
 
 func (r *vdm) preempt() bool {
 	return r.rexray.Config.GetBool("rexray.volume.mount.preempt")
+}
+
+func (r *vdm) disableCreate() bool {
+	return r.rexray.Config.GetBool("rexray.volume.create.disable")
+}
+
+func (r *vdm) disableRemove() bool {
+	return r.rexray.Config.GetBool("rexray.volume.remove.disable")
 }
 
 func (r *vdm) ignoreUsedCount() bool {


### PR DESCRIPTION
This commit introduces a new option to make sure the create/remove
volume functionality can be disabled from the volume and
integration plugins.