### PR TITLE
Fixed module start timeout to error

### DIFF
--- a/daemon/module/module.go
+++ b/daemon/module/module.go
@@ -318,7 +318,7 @@ func StartModule(name string) error {
 		mod.IsStarted = true
 		log.WithFields(lf).Info("started module")
 	case <-timeout:
-		log.WithFields(lf).Debug("timed out while monitoring module start")
+		return goof.New("timed out while monitoring module start")
 	case sErr := <-startError:
 		return sErr
 	}


### PR DESCRIPTION
The module startup process was previously not reporting the
failure of modules to start from a timeout. This change ensures
an error is returned and that rexray does not start.

```
time="2016-04-16T21:03:42Z" level=info msg="[linux]" 
time="2016-04-16T21:03:42Z" level=info msg="[docker]" 
time="2016-04-16T21:03:42Z" level=info msg="[scaleio]" 
time="2016-04-16T21:03:42Z" level=debug msg="core get drivers" osDrivers=[linux] storageDrivers=[scaleio] volumeDrivers=[docker] 
time="2016-04-16T21:03:45Z" level=error msg="default module(s) failed to start" 
time="2016-04-16T21:03:45Z" level=info msg="service sent registered modules start signals" 
time="2016-04-16T21:03:45Z" level=error msg="service initialized failed" 
time="2016-04-16T21:03:45Z" level=info msg="timed out while monitoring module star" 
```