### PR TITLE
Updated goscaleio for re-auth loop fix

### DIFF
--- a/drivers/storage/ec2/ec2.go
+++ b/drivers/storage/ec2/ec2.go
@@ -14,10 +14,10 @@ import (
 	"github.com/akutz/gofig"
 	"github.com/akutz/goof"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -24,7 +24,7 @@ import:
     repo:    https://github.com/aws/aws-sdk-go.git
     vcs:     git
   - package: github.com/emccode/goscaleio
-    ref:     5b02f78c9e4b331a05271145196c15c6614b9eff
+    ref:     53ea76f52205380ab52b9c1f4ad89321c286bb95
     repo:    https://github.com/emccode/goscaleio.git
     vcs:     git
   - package: github.com/emccode/goxtremio


### PR DESCRIPTION
This commit adds a fix for ScaleIO where bad creds would cause
a re-authentication loop.