### PR TITLE
Fixed module start timeout to error

### DIFF
--- a/daemon/module/module.go
+++ b/daemon/module/module.go
@@ -318,7 +318,7 @@ func StartModule(name string) error {
 		mod.IsStarted = true
 		log.WithFields(lf).Info("started module")
 	case <-timeout:
-		log.WithFields(lf).Debug("timed out while monitoring module start")
+		return goof.New("timed out while monitoring module start")
 	case sErr := <-startError:
 		return sErr
 	}


### PR DESCRIPTION
The module startup process was previously not reporting the
failure of modules to start from a timeout. This change ensures
an error is returned and that rexray does not start.