### PR TITLE
Fixed logging not occuring with Ubuntu 14.04

### DIFF
--- a/rexray/cli/service.go
+++ b/rexray/cli/service.go
@@ -231,7 +231,6 @@ func (c *CLI) tryToStartDaemon() {
 	}
 
 	cmd := exec.Command(thisAbsPath, cmdArgs...)
-	cmd.Stderr = os.Stderr
 
 	cmdErr := cmd.Start()
 	failOnError(cmdErr)


### PR DESCRIPTION
This patch is a fix for issue #365, where the logging is not writing
to /var/log/rexray/rexray.log.

Since os.Stderr is attached to TTY(!log.IsTerminal()) rexray doesn't
write to the log file so I removed cmd.Stderr.

Follow up: https://github.com/emccode/rexray/pull/373