### PR TITLE
Feature/docker volume mountpath

### DIFF
--- a/rexray/cli/cli.go
+++ b/rexray/cli/cli.go
@@ -319,6 +319,10 @@ func (c *CLI) preRun(cmd *cobra.Command, args []string) {
 
 	c.updateLogLevel()
 
+	if !c.config.IsSet("docker.mountDirPath") {
+		c.config.Set("docker.mountDirPath", util.LibFilePath("volumes"))
+	}
+
 	c.config = c.config.Scope("rexray.modules.default-docker")
 
 	if isHelpFlag(cmd) {
@@ -346,6 +350,10 @@ func (c *CLI) preRun(cmd *cobra.Command, args []string) {
 		if c.runAsync {
 			c.ctx = c.ctx.WithValue("async", true)
 		}
+		if !c.config.IsSet("docker.mountDirPath") {
+			c.config.Set("docker.mountDirPath", util.LibFilePath("volumes"))
+		}
+
 		r, rs, err, _ := libstorage.New(c.config.Scope("rexray"))
 		if err == nil {
 			c.r = r


### PR DESCRIPTION
This commit introduces a new configurable field for
docker.volume.mountPath to choose the default location of
mounted volumes. A path of /var/lib/rexray/volumes is still
default as a base.

This has a commit from @akutz below this one.