### PR TITLE
Fixed cli commands to for nil exceptions

### DIFF
--- a/rexray/cli/cmds_volume.go
+++ b/rexray/cli/cmds_volume.go
@@ -167,7 +167,10 @@ func (c *CLI) initVolumeCmds() {
 
 			vol, _, err := c.r.Storage().VolumeAttach(
 				c.ctx, c.volumeID,
-				&apitypes.VolumeAttachOpts{Force: c.force})
+				&apitypes.VolumeAttachOpts{
+					Force: c.force,
+					Opts:  store(),
+				})
 
 			if err != nil {
 				log.Fatal(err)
@@ -193,7 +196,10 @@ func (c *CLI) initVolumeCmds() {
 			}
 
 			_, err := c.r.Storage().VolumeDetach(
-				c.ctx, c.volumeID, &apitypes.VolumeDetachOpts{Force: c.force})
+				c.ctx, c.volumeID, &apitypes.VolumeDetachOpts{
+					Force: c.force,
+					Opts:  store(),
+				})
 			if err != nil {
 				log.Fatal(err)
 			}


### PR DESCRIPTION
The CLI commands were fixed to ensure the proper store option
is being passed.