### PR TITLE
temporarily removed snapshot functionality

### DIFF
--- a/rexray/cli/cli.go
+++ b/rexray/cli/cli.go
@@ -198,7 +198,7 @@ func NewWithArgs(a ...string) *CLI {
 	c.initAdapterCmdsAndFlags()
 	c.initDeviceCmdsAndFlags()
 	c.initVolumeCmdsAndFlags()
-	c.initSnapshotCmdsAndFlags()
+	// c.initSnapshotCmdsAndFlags()
 
 	c.initServiceCmdsAndFlags()
 	c.initModuleCmdsAndFlags()


### PR DESCRIPTION
This commit removes the snapshot command from the CLI. The current
libstorage driver package does not include snapshot functionality
in the available drivers. Once there is support, this should be
added back with the updated libstorage package.