### PR TITLE
Bugfix for -c/--config flag

### DIFF
--- a/daemon/module/module.go
+++ b/daemon/module/module.go
@@ -2,6 +2,7 @@ package module
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -9,6 +10,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/akutz/gofig"
 	"github.com/akutz/goof"
+	"github.com/akutz/gotil"
 )
 
 // Module is the interface to which types adhere in order to participate as
@@ -147,6 +149,15 @@ func InitializeDefaultModules() error {
 	defer modTypesRwl.RUnlock()
 
 	c := gofig.New().Scope("rexray")
+
+	if cfgFile := os.Getenv("REXRAY_CONFIG_FILE"); cfgFile != "" {
+		if gotil.FileExists(cfgFile) {
+			if err := c.ReadConfigFile(cfgFile); err != nil {
+				panic(err)
+			}
+		}
+	}
+
 	modConfigs, err := getConfiguredModules(c)
 	if err != nil {
 		return err

--- a/rexray/cli/cli.go
+++ b/rexray/cli/cli.go
@@ -314,6 +314,7 @@ func (c *CLI) preRun(cmd *cobra.Command, args []string) {
 		if err := c.config.ReadConfigFile(c.cfgFile); err != nil {
 			panic(err)
 		}
+		os.Setenv("REXRAY_CONFIG_FILE", c.cfgFile)
 		cmd.Flags().Parse(os.Args[1:])
 	}
 

--- a/rexray/cli/service.go
+++ b/rexray/cli/service.go
@@ -230,6 +230,9 @@ func (c *CLI) tryToStartDaemon() {
 	if c.host() != "" {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("--host=%s", c.host()))
 	}
+	if c.cfgFile != "" {
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--config=%s", c.cfgFile))
+	}
 
 	cmd := exec.Command(thisAbsPath, cmdArgs...)
 


### PR DESCRIPTION
This patch fixes the issue of a config file specified by the command line not being respected by modules.