### PR TITLE
Always Deploy RPMs/DEBs

### DIFF
--- a/.build/bintray-stable.json
+++ b/.build/bintray-stable.json
@@ -14,7 +14,7 @@
 
     "files": [
         {
-            "includePattern": ".build/deploy/(.+)/(.*\.tar\.gz)",
+            "includePattern": ".build/deploy/(.+)/(.*\.(?:(?:tar\.gz)|rpm|deb))",
             "excludePattern": ".build/deploy/latest/(.*)",
             "uploadPattern": "stable/${SEMVER}/$2"
         },

--- a/.build/bintray-staged.json
+++ b/.build/bintray-staged.json
@@ -14,7 +14,7 @@
 
     "files": [
         {
-            "includePattern": ".build/deploy/(.+)/(.*\.tar\.gz)",
+            "includePattern": ".build/deploy/(.+)/(.*\.(?:(?:tar\.gz)|rpm|deb))",
             "excludePattern": ".build/deploy/latest/(.*)",
             "uploadPattern": "staged/${SEMVER}/$2"
         },

--- a/.build/bintray-stupid.json
+++ b/.build/bintray-stupid.json
@@ -14,7 +14,7 @@
 
     "files": [
         {
-            "includePattern": ".build/deploy/(.+)/(.*\.tar\.gz)",
+            "includePattern": ".build/deploy/(.+)/(.*\.(?:(?:tar\.gz)|rpm|deb))",
             "excludePattern": ".build/deploy/latest/(.*)",
             "uploadPattern": "unstable/${SEMVER}/$2"
         },


### PR DESCRIPTION
This patch modifies the deployment process so that RPM and DEB files are always deployed, not just to the latest staging area.