### PR TITLE
Fix for path caching and  volumes listing on CLI commands

### DIFF
--- a/rexray/cli/cmds_volume.go
+++ b/rexray/cli/cmds_volume.go
@@ -57,7 +57,6 @@ func (c *CLI) initVolumeCmds() {
 		Short:   "Get one or more volumes",
 		Aliases: []string{"ls", "list"},
 		Run: func(cmd *cobra.Command, args []string) {
-
 			vols, err := c.r.Storage().Volumes(
 				c.ctx, &apitypes.VolumesOpts{Attachments: false})
 			if err != nil {


### PR DESCRIPTION
To cache the paths of known mounted volumes, a listing is done
on startup for module and CLI. When using from CLI, the path
cache is not necessary.