### PR TITLE
Updated default mountdirpath

### DIFF
--- a/daemon/module/module.go
+++ b/daemon/module/module.go
@@ -13,6 +13,7 @@ import (
 	"github.com/akutz/gotil"
 	"github.com/emccode/libstorage"
 	apitypes "github.com/emccode/libstorage/api/types"
+	"github.com/emccode/rexray/util"
 )
 
 // Module is the interface to which types adhere in order to participate as
@@ -159,6 +160,11 @@ func InitializeDefaultModules() error {
 				panic(err)
 			}
 		}
+	}
+
+	if !c.IsSet("libstorage.integration.docker.mountDirPath") {
+		c.Set("libstorage.integration.docker.mountDirPath",
+			util.LibFilePath("volumes"))
 	}
 
 	lsc, _, err, errs := libstorage.New(c)

--- a/rexray/cli/cli.go
+++ b/rexray/cli/cli.go
@@ -320,10 +320,12 @@ func (c *CLI) preRun(cmd *cobra.Command, args []string) {
 
 	c.updateLogLevel()
 
-	if !c.config.IsSet("docker.mountDirPath") {
-		c.config.Set("docker.mountDirPath", util.LibFilePath("volumes"))
+	if !c.config.IsSet(
+		"libstorage.integration.docker.mountDirPath") {
+		c.config.Set(
+			"libstorage.integration.docker.mountDirPath",
+			util.LibFilePath("volumes"))
 	}
-
 	c.config = c.config.Scope("rexray.modules.default-docker")
 
 	if isHelpFlag(cmd) {
@@ -350,9 +352,6 @@ func (c *CLI) preRun(cmd *cobra.Command, args []string) {
 		}
 		if c.runAsync {
 			c.ctx = c.ctx.WithValue("async", true)
-		}
-		if !c.config.IsSet("docker.mountDirPath") {
-			c.config.Set("docker.mountDirPath", util.LibFilePath("volumes"))
 		}
 
 		r, rs, err, _ := libstorage.New(c.config.Scope("rexray"))


### PR DESCRIPTION
The default mountdirpath is now to set /var/lib/rexray/volumes for
both the CLI and module startup.