### PR TITLE
Updated CLI to not enable pathcache

### DIFF
--- a/rexray/cli/cli.go
+++ b/rexray/cli/cli.go
@@ -326,6 +326,14 @@ func (c *CLI) preRun(cmd *cobra.Command, args []string) {
 			"libstorage.integration.docker.mountDirPath",
 			util.LibFilePath("volumes"))
 	}
+
+	if !c.config.IsSet(
+		"libstorage.integration.volume.path.cache") {
+		c.config.Set(
+			"libstorage.integration.volume.path.cache",
+			false)
+	}
+
 	c.config = c.config.Scope("rexray.modules.default-docker")
 
 	if isHelpFlag(cmd) {


### PR DESCRIPTION
Since a CLI starts and exits, the extra overhead required from
enabling the caching of doing a list attached method on launch is
not needed.