### PR TITLE
Fix for starting libs client from module

### DIFF
--- a/daemon/module/module.go
+++ b/daemon/module/module.go
@@ -167,7 +167,7 @@ func InitializeDefaultModules() error {
 			util.LibFilePath("volumes"))
 	}
 
-	lsc, _, err, errs := libstorage.New(c)
+	_, _, err, errs := libstorage.New(c)
 	if err != nil {
 		return err
 	}
@@ -184,6 +184,10 @@ func InitializeDefaultModules() error {
 	}
 
 	for _, mc := range modConfigs {
+		lsc, err := libstorage.Dial(mc.Config)
+		if err != nil {
+			panic(err)
+		}
 		mc.Client = lsc
 		mod, err := InitializeModule(mc)
 		if err != nil {


### PR DESCRIPTION
This commit makes it so that libstorage client is started once
per module. This allows you to configure libs client settings
including volume and integration settings per module.