### PR TITLE
Feature/module startup timeout

### DIFF
--- a/daemon/module/docker/volumedriver/voldriver.go
+++ b/daemon/module/docker/volumedriver/voldriver.go
@@ -74,11 +74,7 @@ func newModule(c *module.Config) (module.Module, error) {
 		cc.Set("rexray.volume.path.cache", true)
 	}
 
-	ctx := context.Background().WithContextID(
-		"module", c.Name,
-	).WithServiceName(
-		cc.GetString("libstorage.service"),
-	)
+	ctx := context.Background()
 
 	return &mod{
 		ctx:    ctx,
@@ -236,7 +232,7 @@ func (m *mod) Address() string {
 func (m *mod) buildMux() *http.ServeMux {
 
 	mux := http.NewServeMux()
-	m.ctx.WithServiceName(m.ctx.ServiceName())
+	// m.ctx.WithServiceName(m.ctx.ServiceName())
 
 	mux.HandleFunc("/Plugin.Activate", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1.2+json")

--- a/daemon/module/module.go
+++ b/daemon/module/module.go
@@ -106,6 +106,7 @@ rexray:
             spec:     /etc/docker/plugins/rexray.spec
             disabled: false
 `)
+	cfg.Key(gofig.String, "", "10s", "", "rexray.module.startTimeout")
 	gofig.Register(cfg)
 }
 
@@ -344,7 +345,7 @@ func StartModule(name string) error {
 	}()
 
 	go func() {
-		time.Sleep(3 * time.Second)
+		time.Sleep(startTimeout())
 		timeout <- true
 	}()
 
@@ -406,4 +407,13 @@ func getConfiguredModules(c gofig.Config) ([]*Config, error) {
 	}
 
 	return modConfigs, nil
+}
+
+func startTimeout() time.Duration {
+	c := gofig.New()
+	dur, err := time.ParseDuration(c.GetString("rexray.module.startTimeout"))
+	if err != nil {
+		return time.Duration(10) * time.Second
+	}
+	return dur
 }

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/emccode/rexray
 import:
   - package: github.com/emccode/libstorage
-    ref:     v0.1.0-rc2
+    ref:     8d0aaaec8cc523697e6ee8de80a22585a4ab58e1
   - package: github.com/Sirupsen/logrus
     ref:     feature/logrus-aware-types
     repo:    https://github.com/akutz/logrus

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,6 @@
 package: github.com/emccode/rexray
 import:
   - package: github.com/emccode/libstorage
-    ref:     8d0aaaec8cc523697e6ee8de80a22585a4ab58e1
   - package: github.com/Sirupsen/logrus
     ref:     feature/logrus-aware-types
     repo:    https://github.com/akutz/logrus

--- a/rexray/cli/cli.go
+++ b/rexray/cli/cli.go
@@ -354,9 +354,9 @@ func (c *CLI) preRun(cmd *cobra.Command, args []string) {
 
 	if c.isInitDriverManagersCmd(cmd) {
 		c.ctx = context.Background()
-		if c.service != "" && !c.config.IsSet(apitypes.ConfigService) {
-			c.ctx = c.ctx.WithServiceName(c.service)
-		}
+		// if c.service != "" && !c.config.IsSet(apitypes.ConfigService) {
+		// 	c.ctx = c.ctx.WithServiceName(c.service)
+		// }
 		if c.runAsync {
 			c.ctx = c.ctx.WithValue("async", true)
 		}

--- a/rexray/cli/cmds_adapter.go
+++ b/rexray/cli/cmds_adapter.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -57,11 +56,6 @@ func (c *CLI) initAdapterCmds() {
 				log.Fatalf("Error: %s", err)
 			}
 
-			if strings.ToUpper(c.outputFormat) != "JSON" {
-				for _, i := range instances {
-					i.InstanceID.Metadata = nil
-				}
-			}
 			if len(instances) > 0 {
 				out, err := c.marshalOutput(&instances)
 				if err != nil {


### PR DESCRIPTION
This includes multiple commits. The first are minor tweaks that I believe are relevant to changes in the context with libs and metadata. The other is a new configurable setting for module timeout so that longer running pathcache/volume list+attachments operations do not cause the modules startup to fail.