### PR TITLE
update to remove dependency on perl for 'list' feature

### DIFF
--- a/.build/install
+++ b/.build/install
@@ -68,8 +68,8 @@ list() {
     else
         URL="$URL/$PKG"
         for v in $(curl -sSL $URL | \
-                   grep '<a' | grep -v 'latest' | \
-                   perl -pe 's/^.*?<a.+?>([^<]+?)\/?<\/a>.*$/$1/gm'); do
+                   grep 'onclick' | grep -v 'latest' | \
+		   cut -d '>' -f3 | cut -d'/' -f1); do
             echo "$SCRIPT_CMD $PKG $v -"
         done
     fi


### PR DESCRIPTION
The install relies on perl for a single-line rexex when scraping the
Bintray website for a list of REX-Ray versions available for install.

This tiny update removes the need for the installing operating system to
have Perl installed, mostly because RHEL does not have Perl installed by
default. One other option would have been to trap the error and echo
some sort of message calling for the user to install Perl, but that
seems drastic, considering the same page scrape can be executed just
fine using the bash built-in command 'cut'.

This update should not affect any other versions, as 'cut' hasn't really
changed its syntax in decades.