### PR TITLE
Fixed error channel instead of error on libstorage start

### DIFF
--- a/daemon/module/docker/volumedriver/voldriver.go
+++ b/daemon/module/docker/volumedriver/voldriver.go
@@ -109,8 +109,7 @@ type pluginRequest struct {
 
 func (m *mod) Start() error {
 
-	lsc, _, err, _ := libstorage.New(m.config)
-
+	lsc, _, _, err := libstorage.New(m.config)
 	if err != nil {
 		for k, v := range m.config.AllSettings() {
 			m.ctx.Errorf("%s=%v", k, v)


### PR DESCRIPTION
This commit fixes a problem where the service was failing to start
since the error channel position was changed on the underlying
New() method resulting in a false positive with each start.