### PR TITLE
libStorage Context Parameter

### DIFF
--- a/daemon/module/module.go
+++ b/daemon/module/module.go
@@ -182,7 +182,7 @@ func InitializeDefaultModules(
 				"not starting embeddded server; " +
 					"local server already running")
 		} else {
-			if server, errs, err = apiserver.Serve(config); err != nil {
+			if server, errs, err = apiserver.Serve(ctx, config); err != nil {
 				return nil, err
 			}
 			go func() {
@@ -206,7 +206,7 @@ func InitializeDefaultModules(
 
 	for _, mc := range modConfigs {
 
-		lsc, err := apiclient.New(mc.Config)
+		lsc, err := apiclient.New(ctx, mc.Config)
 		if err != nil {
 			panic(err)
 		}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 834ae4500ea813ff51a645ecad006a34c87aad56190ee19c357c93316a8f132c
-updated: 2016-06-02T00:11:06.462539812-05:00
+updated: 2016-06-02T05:57:20.839155182-05:00
 imports:
 - name: github.com/akutz/gofig
   version: 021bbefbfe234a3b72dc9137847483f5b997cbd0
@@ -41,14 +41,14 @@ imports:
   subpackages:
   - types/v1
 - name: github.com/emccode/libstorage
-  version: ad4810db3d11ae6e3adac24c53bf526fc733e1c7
+  version: 22292c9c129d8bd26f64593a611ad520e912005f
   subpackages:
   - imports/local
   - imports/remote
   - api/types
+  - api/context
   - api/server
   - client
-  - api/context
   - api/utils
   - api
   - drivers/integration/docker

--- a/rexray/cli/cli.go
+++ b/rexray/cli/cli.go
@@ -389,7 +389,8 @@ func (c *CLI) preRun(cmd *cobra.Command, args []string) {
 
 				apiserver.CloseOnAbort()
 
-				if c.rs, c.rsErrs, err = apiserver.Serve(config); err == nil {
+				if c.rs, c.rsErrs, err = apiserver.Serve(
+					c.ctx, config); err == nil {
 					go func() {
 						err := <-c.rsErrs
 						if err != nil {
@@ -405,7 +406,7 @@ func (c *CLI) preRun(cmd *cobra.Command, args []string) {
 		}
 
 		if err == nil {
-			c.r, err = apiclient.New(config)
+			c.r, err = apiclient.New(c.ctx, config)
 		}
 
 		if err != nil {


### PR DESCRIPTION
This patch updates REX-Ray to use the context parameter when creating
libStorage servers and clients.