### PR TITLE
Allow RexRay Http Client Timeout Configurable

### DIFF
--- a/daemon/module/docker/volumedriver/voldriver.go
+++ b/daemon/module/docker/volumedriver/voldriver.go
@@ -152,11 +152,13 @@ func (m *mod) Start() error {
 	} else {
 		specPath = addr
 		startFunc = func() error {
+			readTimeout := m.config.GetInt("http.readtimeout")
+			writeTimeout := m.config.GetInt("http.writetimeout")
 			s := &http.Server{
 				Addr:           addr,
 				Handler:        mux,
-				ReadTimeout:    10 * time.Second,
-				WriteTimeout:   10 * time.Second,
+				ReadTimeout:    time.Duration(readTimeout) * time.Second,
+				WriteTimeout:   time.Duration(writeTimeout) * time.Second,
 				MaxHeaderBytes: 1 << 20,
 			}
 			return s.ListenAndServe()

--- a/daemon/module/module.go
+++ b/daemon/module/module.go
@@ -105,6 +105,9 @@ rexray:
             desc:     The default docker module.
             host:     unix:///run/docker/plugins/rexray.sock
             spec:     /etc/docker/plugins/rexray.spec
+            http:
+              writetimeout: 10
+              readtimeout: 10
             disabled: false
 `)
 	cfg.Key(gofig.String, "", "10s", "", "rexray.module.startTimeout")


### PR DESCRIPTION
When running libstorage with our scaleIO setup sometimes mount/unmount takes longer than 10 seconds. With this PR we introduce an extra config parameter that can be set in the configuration.yml file to adjust the timeout. The default will remain at 10 seconds.