### PR TITLE
Fix for Embedded libStorage Server IsActive

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -305,7 +305,7 @@ func IsLocalServerActive(
 			return "", false
 		}
 		ctx.WithField("port", port).Debug("is local tcp server active")
-		return host, gotil.IsTCPPortAvailable(port)
+		return host, !gotil.IsTCPPortAvailable(port)
 	}
 	return "", false
 }


### PR DESCRIPTION
This patch fixes issue #461 where the IsLocalServerActive function is
not returning the correct flag for detecting if the libStorage server is
already running.