### PR TITLE
Fix squashing the error (vol = nil) when doing a volume create

### DIFF
--- a/rexray/cli/cmds_volume.go
+++ b/rexray/cli/cmds_volume.go
@@ -96,10 +96,6 @@ func (c *CLI) initVolumeCmds() {
 		Aliases: []string{"new"},
 		Run: func(cmd *cobra.Command, args []string) {
 
-			if c.size == 0 && c.snapshotID == "" && c.volumeID == "" {
-				log.Fatalf("missing --size")
-			}
-
 			opts := &apitypes.VolumeCreateOpts{
 				AvailabilityZone: &c.availabilityZone,
 				Size:             &c.size,
@@ -119,7 +115,7 @@ func (c *CLI) initVolumeCmds() {
 			} else if c.snapshotID != "" && c.volumeName != "" {
 				volume, err = c.r.Storage().VolumeCreateFromSnapshot(
 					c.ctx, c.snapshotID, c.volumeName, opts)
-			} else if c.volumeName != "" {
+			} else {
 				volume, err = c.r.Storage().VolumeCreate(
 					c.ctx, c.volumeName, opts)
 			}


### PR DESCRIPTION
The issue https://github.com/emccode/polly/issues/88 was reported in Polly, but the root cause exists in rexray.

```
root@node1:/tmp# rexray volume create --volumename=haha
FATA[0001] error creating new volume                     inner.size=0 inner.volumeName=haha inner.provider=virtualbox status=500
```