### PR TITLE
Removed Admin Module Fix

### DIFF
--- a/daemon/module/module.go
+++ b/daemon/module/module.go
@@ -93,11 +93,6 @@ func initConfig() {
 	cfg.Yaml(`
 rexray:
     modules:
-        default-admin:
-            type:     admin
-            desc:     The default admin module.
-            host:     unix:///var/run/rexray/server.sock
-            disabled: false
         default-docker:
             type:     docker
             desc:     The default docker module.


### PR DESCRIPTION
This patch fixes an issue introduced by the removal of the admin module.
The default YAML for said module was not also removed, resulting in a
failed configuration at runtime.