### PR TITLE
GOPATH/bin, Gometalinter, Glide Install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,26 @@ language: go
 go:
   - 1.6
 
-addons:
-  apt:
-    packages:
-    - rpm
-
-before_script:
+before_install:
+  - git config --global 'url.https://gopkg.in/yaml.v1.insteadof' 'https://gopkg.in/yaml.v1/'
+  - git config --global 'url.https://gopkg.in/yaml.v2.insteadof' 'https://gopkg.in/yaml.v2/'
+  - git config --global 'url.https://gopkg.in/fsnotify.v1.insteadof' 'https://gopkg.in/fsnotify.v1/'
+  - git config --global 'url.https://github.com/.insteadof' 'git://github.com/'
+  - git config --global 'url.https://github.com/.insteadof' 'git@github.com:'
+  - go get github.com/onsi/gomega
+  - go get github.com/onsi/ginkgo
+  - go get golang.org/x/tools/cmd/cover
   - make deps
 
 script:
-  - make build-libstorage
-  - env GOOS=linux  GOARCH=amd64 make build
-  - env GOOS=darwin GOARCH=amd64 make build
-  - make cover
+  - make gometalinter-all
+  - make -j build-libstorage
+  - env GOOS=linux  GOARCH=amd64 make -j build
+  - env GOOS=darwin GOARCH=amd64 make -j build
+  - make -j test
 
 after_success:
+  - make -j cover
   - make tgz
   - make rpm
   - make deb
@@ -57,4 +62,9 @@ deploy:
 cache:
   apt: true
   directories:
-    - $HOME/.opt
+  - $HOME/.opt
+
+addons:
+  apt:
+    packages:
+    - rpm


### PR DESCRIPTION
This patch provides three enhancements to the build process:

  1. GOPATH/bin is automatically added and exported to the system's PATH
  variable for the duration of the Makefile's execution. This ensures
  that any commands which invoke a command assumed to be in the PATH via
  $GOPATH/bin will function correctly.

  2. The Gometalinter tool has been integrated into the build process in
  order to ensure consistent, clean, functional code.

  3. The Glide target now uses `glide install` instead of `glide up` in
  order to prevent the creation of a new `glide.lock` file on the build
  agent at the time of a build.