### PR TITLE
Improved Path Caching

### DIFF
--- a/daemon/module/docker/volumedriver/voldriver.go
+++ b/daemon/module/docker/volumedriver/voldriver.go
@@ -59,10 +59,6 @@ func newModule(ctx apitypes.Context, c *module.Config) (module.Module, error) {
 	c.Address = host
 	config := c.Config
 
-	if !config.GetBool("rexray.volume.path.disableCache") {
-		config.Set("rexray.volume.path.cache", true)
-	}
-
 	return &mod{
 		ctx:    ctx,
 		config: config,

--- a/daemon/module/module.go
+++ b/daemon/module/module.go
@@ -156,6 +156,9 @@ func InitializeDefaultModules(
 		errs <-chan error
 	)
 
+	// enable path caching for the modules
+	config.Set(apitypes.ConfigIgVolOpsPathCacheEnabled, true)
+
 	ctx, config, errs, err = util.ActivateLibStorage(ctx, config)
 	if err != nil {
 		return nil, err

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: bf559baf6b7d3b5a4e64c00fdea50bfb482b84d1ded225120184039f76194b78
-updated: 2016-07-11T01:15:32.201289117-05:00
+hash: 9a4c6350a424c4bf7789a5303397e9dedd3f3181b4b5c42e0e7a1bee5cfa9bab
+updated: 2016-07-11T04:48:23.009694212-05:00
 imports:
 - name: github.com/akutz/gofig
   version: 697c16916338166671910eeaccc50f21e3c10726
@@ -41,7 +41,7 @@ imports:
   subpackages:
   - types/v1
 - name: github.com/emccode/libstorage
-  version: fd13a81478c5b326d47a8cfde292ed70c3198e24
+  version: e71c821448a83c60752f917b729389cfe303f64c
   subpackages:
   - imports/local
   - imports/remote

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,7 +10,7 @@ import:
     repo:    https://github.com/akutz/logrus
 
   - package: github.com/emccode/libstorage
-    version: v0.1.5-rc1
+    version: v0.1.5-rc2
 
   - package: github.com/akutz/gofig
     version: v0.1.4

--- a/rexray/cli/cli.go
+++ b/rexray/cli/cli.go
@@ -322,6 +322,9 @@ func (c *CLI) preRun(cmd *cobra.Command, args []string) {
 
 	c.updateLogLevel()
 
+	// disable path caching for the CLI
+	c.config.Set(apitypes.ConfigIgVolOpsPathCacheEnabled, false)
+
 	if v := c.rrHost(); v != "" {
 		c.config.Set(apitypes.ConfigHost, v)
 	}


### PR DESCRIPTION
This patch addresses #466 and updates REX-Ray to use libStorage 0.1.5-rc2 with its own path caching enhancements. The largest change is that volume path caching is now disabled for REX-Ray when it is executed from the CLI. When operating as a Docker Volume Endpoint, caching is still enabled.