### PR TITLE
REX-Ray Production Profiling

### DIFF
--- a/rexray/rexray.go
+++ b/rexray/rexray.go
@@ -1,11 +1,43 @@
 package main
 
 import (
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+	"runtime/pprof"
+	"runtime/trace"
+
 	"github.com/emccode/rexray/rexray/cli"
 
 	// load REX-Ray
 	_ "github.com/emccode/rexray"
 )
+
+func init() {
+	if p := os.Getenv("REXRAY_TRACE_PROFILE"); p != "" {
+		f, err := os.Create(p)
+		if err != nil {
+			panic(err)
+		}
+		if err := trace.Start(f); err != nil {
+			panic(err)
+		}
+		defer trace.Stop()
+	}
+
+	if p := os.Getenv("REXRAY_CPU_PROFILE"); p != "" {
+		f, err := os.Create(p)
+		if err != nil {
+			panic(err)
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
+	}
+
+	if p := os.Getenv("REXRAY_PROFILE_ADDR"); p != "" {
+		go http.ListenAndServe(p, http.DefaultServeMux)
+	}
+}
 
 func main() {
 	cli.Execute()


### PR DESCRIPTION
This patch adds the capability to profile REX-Ray at runtime in
production. Three new environment variables are introduced:

## REXRAY_TRACE_PROFILE
Setting the environment variable `REXRAY_TRACE_PROFILE` to a valid file
path causes REX-Ray to use the Golang "runtime/trace" package to create
a trace dump of the process execution. This file can then be analyzed
using `go tool trace $(which rexray) $REXRAY_TRACE_PROFILE`.

## REXRAY_CPU_PROFILE
Setting the environment variable `REXRAY_CPU_PROFILE` to a valid file
path causes REX-Ray to use the Golang "runtime/pprof" package to create
a CPU profile of the process execution. This file can then be analyzed
using `go tool pprof $(which rexray) $REXRAY_CPU_PROFILE`.

## REXRAY_PROFILE_ADDR
Setting the environment variable `REXRAY_PROFILE_ADDR` to a value that
follows the pattern HOST:PORT (ex. "localhost:8989") causes REX-Ray to
load the Golang "net/http/pprof" package and launch a web server on the
provided HOST:PORT combination. This makes it possible to access the
the URL `http://HOST:PORT/debug/pprof` to obtain live profiling
information about the executing REX-Ray process.