### PR TITLE
Fix for Profiler Race Condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,7 +470,8 @@ import (
 
 func init() {
 	Version = &apitypes.VersionInfo{}
-	Version.Arch = fmt.Sprintf("%s-%s", os(runtime.GOOS), arch(runtime.GOARCH))
+	Version.Arch = fmt.Sprintf(
+		"%s-%s", osString(runtime.GOOS), archString(runtime.GOARCH))
 	Version.Branch = "$(V_BRANCH)"
 	Version.BuildTimestamp = time.Unix($(V_EPOCH), 0)
 	Version.SemVer = "$(V_SEMVER)"

--- a/rexray/rexray.go
+++ b/rexray/rexray.go
@@ -6,39 +6,123 @@ import (
 	"os"
 	"runtime/pprof"
 	"runtime/trace"
+	"strconv"
+	"sync"
 
+	log "github.com/Sirupsen/logrus"
+	"github.com/emccode/libstorage/api/context"
+	apitypes "github.com/emccode/libstorage/api/types"
+	"github.com/emccode/rexray/core"
 	"github.com/emccode/rexray/rexray/cli"
 
 	// load REX-Ray
 	_ "github.com/emccode/rexray"
 )
 
-func init() {
+func main() {
+
+	updateLogLevel()
+
+	var (
+		err          error
+		traceProfile *os.File
+		cpuProfile   *os.File
+		ctx          = context.Background()
+		exit         sync.Once
+	)
+
+	onExit := func() {
+		if traceProfile != nil {
+			ctx.Info("stopping trace profile")
+			trace.Stop()
+			traceProfile.Close()
+			ctx.Debug("stopped trace profile")
+		}
+
+		if cpuProfile != nil {
+			ctx.Info("stopping cpu profile")
+			pprof.StopCPUProfile()
+			cpuProfile.Close()
+			ctx.Debug("stopped cpu profile")
+		}
+
+		ctx.Info("exiting process")
+	}
+
+	core.RegisterSignalHandler(func(ctx apitypes.Context, s os.Signal) {
+		if ok, _ := core.IsExitSignal(s); ok {
+			ctx.Info("received exit signal")
+			exit.Do(onExit)
+		}
+	})
+
 	if p := os.Getenv("REXRAY_TRACE_PROFILE"); p != "" {
-		f, err := os.Create(p)
-		if err != nil {
+		if traceProfile, err = os.Create(p); err != nil {
 			panic(err)
 		}
-		if err := trace.Start(f); err != nil {
+		if err = trace.Start(traceProfile); err != nil {
 			panic(err)
 		}
-		defer trace.Stop()
+		ctx.WithField("path", traceProfile.Name()).Info("trace profile enabled")
 	}
 
 	if p := os.Getenv("REXRAY_CPU_PROFILE"); p != "" {
-		f, err := os.Create(p)
-		if err != nil {
+		if cpuProfile, err = os.Create(p); err != nil {
 			panic(err)
 		}
-		pprof.StartCPUProfile(f)
-		defer pprof.StopCPUProfile()
+		if err = pprof.StartCPUProfile(cpuProfile); err != nil {
+			panic(err)
+		}
+		ctx.WithField("path", cpuProfile.Name()).Info("cpu profile enabled")
 	}
 
 	if p := os.Getenv("REXRAY_PROFILE_ADDR"); p != "" {
 		go http.ListenAndServe(p, http.DefaultServeMux)
+		ctx.WithField("address", p).Info("http pprof enabled")
+	}
+
+	core.TrapSignals(ctx)
+	ctx.Debug("trapped signals")
+
+	cli.Execute(ctx)
+	ctx.Debug("completed cli execution")
+
+	exit.Do(onExit)
+	ctx.Debug("completed onExit at end of program")
+}
+
+func updateLogLevel() {
+	if ok, _ := strconv.ParseBool(os.Getenv("REXRAY_DEBUG")); ok {
+		enableDebugMode()
+		return
+	}
+
+	if ok, _ := strconv.ParseBool(os.Getenv("LIBSTORAGE_DEBUG")); ok {
+		enableDebugMode()
+		return
+	}
+
+	if ll := os.Getenv("REXRAY_LOG_LEVEL"); ll != "" {
+		if lvl, err := log.ParseLevel(ll); err != nil {
+			setLogLevels(lvl)
+			return
+		}
+	}
+
+	if ll := os.Getenv("LIBSTORAGE_LOGGING_LEVEL"); ll != "" {
+		if lvl, err := log.ParseLevel(ll); err != nil {
+			setLogLevels(lvl)
+		}
 	}
 }
 
-func main() {
-	cli.Execute()
+func enableDebugMode() {
+	log.SetLevel(log.DebugLevel)
+	apitypes.Debug = true
+	setLogLevels(log.DebugLevel)
+}
+
+func setLogLevels(lvl log.Level) {
+	os.Setenv("REXRAY_LOGLEVEL", lvl.String())
+	os.Setenv("LIBSTORAGE_LOGGING_LEVEL", lvl.String())
 }

--- a/util/util.go
+++ b/util/util.go
@@ -377,8 +377,6 @@ func ActivateLibStorage(
 
 	ctx.Debug("starting embedded libStorage server")
 
-	apiserver.CloseOnAbort()
-
 	if server, errs, err = apiserver.Serve(ctx, config); err != nil {
 		return ctx, config, nil, err
 	}


### PR DESCRIPTION
The profiler added to REX-Ray worked fine until it was relocated to the `init()` function from the `main()` function. This was done in hopes of capturing the effects of loading the other packages. However, it ended up stalling the application randomly, likely because of a race condition created trying to load profiling when the profiling packages were not yet loaded themselves.

This patch moves the profiler code back into the `main()` function.

This patch also makes the program behave differently upon being asked to close via a signal. If the application is running as a foreground service and Ctrl-C is used to quit, that actually sends the SIGINT signal. This will allow for a graceful shutdown and a successful exit code. However, using the `kill` command normally or with `kill -9` causes the program to abort immediately with a non-zero exit code.

Signal | Graceful Shutdown | Exit Code | Method
-------|--------------------|-----------|-------- 
SIGKILL | no | 1 | `kill -KILL PID`
SIGTERM | no | 1 | `kill PID` (or `kill -TERM PID`)
SIGHUP | yes | 0 | `kill -HUP PID`
SIGINT | yes | 0 | `kill -INT PID` (if the service is running in the foreground, using `Ctrl-C` to stop the service actually sends the process this signal)
SIGQUIT | yes | 0 | `kill -QUIT PID` (if the service is running in the foreground, using `Ctrl-\` to stop the service actually sends the process this signal)