### PR TITLE
Adds a No-SSL-Warning Installation Option

### DIFF
--- a/install
+++ b/install
@@ -53,6 +53,10 @@ URL=$BINTRAY_URL/$REPO
 SCRIPT_URL=$URL/install
 SCRIPT_CMD="curl -sSL $SCRIPT_URL | sh -s"
 
+if [ "$INSECURE" = "1" ]; then
+    INSECURE=-k
+fi
+
 sudo() {
     if [ "$(id -u)" -eq "0" ]; then $@; else $SUDO $@; fi
 }
@@ -68,7 +72,7 @@ list() {
         echo "$SCRIPT_CMD -- list stable"
     else
         URL="$URL/$PKG"
-        for v in $(curl -sSL $URL | \
+        for v in $(curl $INSECURE -sSL $URL | \
                     grep 'onclick' | grep -v 'latest' | \
                     cut -d '>' -f3 | cut -d'/' -f1); do
             echo "$SCRIPT_CMD -- $PKG $v"
@@ -87,7 +91,7 @@ install() {
 
     if [ "$VERSION" = "latest" ]; then
         VURL=https://api.bintray.com/packages/emccode/$REPO/$PKG/versions/_latest
-        VERSION=$(curl -sSL $VURL | cut -d '"' -f4)
+        VERSION=$(curl $INSECURE -sSL $VURL | cut -d '"' -f4)
     fi
 
     OS=$(uname -s)
@@ -104,7 +108,7 @@ install() {
         FILE_NAME=$BIN_NAME-$FVERSION-1.$ARCH.rpm
         URL=$URL/$FILE_NAME
 
-        curl -o $FILE_NAME -sSL $URL
+        curl $INSECURE -o $FILE_NAME -sSL $URL
         if [ "$?" -ne "0" ]; then exit $?; fi
 
         sudo rpm -ih --quiet $FILE_NAME > /dev/null
@@ -123,7 +127,7 @@ install() {
         FILE_NAME=${BIN_NAME}_${FVERSION}-1_${ARCH}.deb
         URL=$URL/$FILE_NAME
 
-        curl -o $FILE_NAME -sSL $URL
+        curl $INSECURE -o $FILE_NAME -sSL $URL
         if [ "$?" -ne "0" ]; then exit $?; fi
 
         sudo dpkg -i $FILE_NAME
@@ -148,7 +152,7 @@ install() {
         sudo mkdir -p $BIN_DIR
         if [ "$?" -ne "0" ]; then exit $?; fi
 
-        curl -o $FILE_NAME -sSL $URL
+        curl $INSECURE -o $FILE_NAME -sSL $URL
         if [ "$?" -ne "0" ]; then exit $?; fi
 
         sudo tar xzf $FILE_NAME -C $BIN_DIR


### PR DESCRIPTION
This patch adds a No-SSL-Warning installation option to the curl-bash install script. Specifying the flag `INSECURE=1` ahead of the `sh` command after the pipe in the `curl`-bash installation command now causes the script's internal `curl` commands to specify the `-k` flag, indicating that SSL warnings should be ignored.

For example, to list the available, stable releases using the new No-SSL-Warning option, the following command would be used:

```bash
$ curl -ksSL https://dl.bintray.com/emccode/rexray/install | INSECURE=1 sh -s -- list stable
```

Please note in the above example that the `-k` flag must be added manually to the initial `curl` command on the CLI. Setting `INSECURE=1` only instructs the `curl` commands *inside* the fetched install script to use the `-k` flag, not the initial one.