### PR TITLE
Refine rexray volume ls filter

### DIFF
--- a/rexray/cli/cmds_volume.go
+++ b/rexray/cli/cmds_volume.go
@@ -66,14 +66,13 @@ func (c *CLI) initVolumeCmds() {
 			}
 			if c.volumeID != "" || c.volumeName != "" {
 				for _, v := range vols {
-					if strings.ToLower(v.ID) == strings.ToLower(c.volumeID) ||
-						strings.ToLower(v.Name) == strings.ToLower(c.volumeName) {
+					if (c.volumeID != "" && strings.EqualFold(v.ID, c.volumeID)) ||
+						(c.volumeName != "" && strings.EqualFold(v.Name, c.volumeName)) {
 						out, err := c.marshalOutput(v)
 						if err != nil {
 							log.Fatal(err)
 						}
 						fmt.Println(out)
-						return
 					}
 				}
 				return


### PR DESCRIPTION
This commit fixes the following issues:
1. When `rexray volume ls` was used specifying only a volume ID,
either a volume with a blank name, or a volume matching the same
volume ID would be returned.
2. When `rexray volume ls` was used specifying a volume name that
matched multiple volumes, only one volume with a matching volume
name would be returned. In REX-Ray 0.3.0, all volumes that matched
the volume name would be returned.