### PR TITLE
Update Build to Go 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ go_import_path: github.com/emccode/rexray
 language: go
 
 go:
-  - 1.6
+  - 1.7
 
 before_install:
   - git config --global 'url.https://gopkg.in/yaml.v1.insteadof' 'https://gopkg.in/yaml.v1/'


### PR DESCRIPTION
This patch updates the REX-Ray build to use Go 1.7.