### PR TITLE
doc: Re-introduce EBS driver

### DIFF
--- a/.docs/index.md
+++ b/.docs/index.md
@@ -49,13 +49,13 @@ Provider              | Storage Platform(s)
 ----------------------|--------------------
 EMC | [ScaleIO](http://libstorage.readthedocs.io/en/stable/user-guide/storage-providers#scaleio), [Isilon](http://libstorage.readthedocs.io/en/stable/user-guide/storage-providers#isilon)
 [Oracle VirtualBox](http://libstorage.readthedocs.io/en/stable/user-guide/storage-providers#virtualbox) | Virtual Media
+Amazon EC2 | [EBS](http://libstorage.readthedocs.io/en/stable/user-guide/storage-providers#aws-ebs), [EFS](http://libstorage.readthedocs.io/en/stable/user-guide/storage-providers#aws-efs)
 
 Support for the following storage providers will be reintroduced in upcoming
 releases:
 
 Provider              | Storage Platform(s)
 ----------------------|--------------------
-[Amazon EC2](./user-guide/storage-providers.md#coming-soon) | EBS
 [Google Compute Engine](./user-guide/storage-providers.md#coming-soon) | Disk
 [Open Stack](./user-guide/storage-providers.md#coming-soon) | Cinder
 [Rackspace](./user-guide/storage-providers.md#coming-soon) | Cinder

--- a/.docs/user-guide/storage-providers.md
+++ b/.docs/user-guide/storage-providers.md
@@ -25,6 +25,7 @@ Provider              | Storage Platform(s)
 ----------------------|--------------------
 EMC | [ScaleIO](http://libstorage.readthedocs.io/en/stable/user-guide/storage-providers/#scaleio), [Isilon](http://libstorage.readthedocs.io/en/stable/user-guide/storage-providers/#isilon)
 [Oracle VirtualBox](http://libstorage.readthedocs.io/en/stable/user-guide/storage-providers/#virtualbox) | Virtual Media
+Amazon EC2 | [EBS](http://libstorage.readthedocs.io/en/stable/user-guide/storage-providers#aws-ebs), [EFS](http://libstorage.readthedocs.io/en/stable/user-guide/storage-providers#aws-efs)
 
 ## Coming Soon
 Support for the following storage providers will be reintroduced in upcoming
@@ -32,7 +33,6 @@ releases:
 
 Provider              | Storage Platform(s)
 ----------------------|--------------------
-Amazon EC2 | EBS
 Google Compute Engine (GCE) | Disk
 Open Stack | Cinder
 Rackspace | Cinder

--- a/README.md
+++ b/README.md
@@ -65,17 +65,24 @@ REX-Ray can be ran as an interactive CLI to perform volume management
 capabilities.
 
 ```bash
-$ export REXRAY_STORAGEDRIVERS=ec2
-$ export AWS_ACCESSKEY=access_key
-$ export AWS_SECRETKEY=secret_key
+$ export REXRAY_SERVICE=ebs
+$ export EBS_ACCESSKEY=access_key
+$ export EBS_SECRETKEY=secret_key
 $ rexray volume get
 
-- providername: ec2
-  instanceid: i-695bb6ab
-  volumeid: vol-dedbadc3
-  devicename: /dev/sda1
-  region: us-west-1
-  status: attached
+- attachments:
+  - instanceID:
+      id: i-620efed6
+      driver: ebs
+    status: attached
+    volumeID: vol-6ac6c7d6
+  availabilityZone: us-west-1b
+  iops: 100
+  name: ""
+  size: 8
+  status: in-use
+  id: vol-6ac6c7d6
+  type: gp2
 ```
 
 ## Runtime - Service (Docker)
@@ -83,9 +90,9 @@ Additionally, it can be ran as a service to support `Docker`, `Mesos`, and other
  platforms that can communicate through `HTTP/JSON`.
 
 ```bash
-$ export REXRAY_STORAGEDRIVERS=ec2
-$ export AWS_ACCESSKEY=access_key
-$ export AWS_SECRETKEY=secret_key
+$ export REXRAY_SERVICE=ebs
+$ export EBS_ACCESSKEY=access_key
+$ export EBS_SECRETKEY=secret_key
 $ rexray service start
 Starting REX-Ray...SUCCESS!
 
@@ -96,5 +103,4 @@ Starting REX-Ray...SUCCESS!
 
 $ docker run -ti --volume-driver=rexray -v test:/test busybox
 $ df /test
-
 ```


### PR DESCRIPTION
Formerly known as `ec2`, add the ebs driver back into the mix. Add links
to EBS and EFS drivers from libstorage. Also, fixup the README to have a
working example of setting env vars on the CLI and running rexray.