### PR TITLE
Docker Build Enhancements

### DIFF
--- a/glide-docker.yaml
+++ b/glide-docker.yaml
@@ -1,0 +1,51 @@
+package: github.com/emccode/rexray
+import:
+
+################################################################################
+##                           Framework Dependencies                           ##
+################################################################################
+
+  - package: github.com/Sirupsen/logrus
+    ref:     feature/logrus-aware-types
+    repo:    https://github.com/akutz/logrus
+
+  - package: github.com/emccode/libstorage
+    ref:     master
+
+  - package: github.com/akutz/gofig
+    version: v0.1.4
+  - package: github.com/akutz/gotil
+    version: v0.1.0
+  - package: github.com/akutz/goof
+    version: v0.1.0
+  - package: github.com/akutz/golf
+    version: v0.1.1
+
+  - package: github.com/spf13/pflag
+    ref:     b084184666e02084b8ccb9b704bf0d79c466eb1d
+    repo:    https://github.com/spf13/pflag
+  - package: github.com/spf13/cobra
+    ref:     363816bb13ce1710460c2345017fd35593cbf5ed
+    repo:    https://github.com/akutz/cobra
+  - package: github.com/go-yaml/yaml
+    ref:     b4a9f8c4b84c6c4256d669c649837f1441e4b050
+    repo:    https://github.com/akutz/yaml.git
+  - package: gopkg.in/yaml.v1
+    ref:     b4a9f8c4b84c6c4256d669c649837f1441e4b050
+    repo:    https://github.com/akutz/yaml.git
+  - package: gopkg.in/yaml.v2
+    ref:     b4a9f8c4b84c6c4256d669c649837f1441e4b050
+    repo:    https://github.com/akutz/yaml.git
+  - package: google.golang.org/api/compute/v1
+    ref:     fd081149e482b10c55262756934088ffe3197ea3
+    repo:    https://github.com/google/google-api-go-client.git
+  - package: golang.org/x/net
+    repo:    https://github.com/golang/net
+
+################################################################################
+##                         Storage Driver Dependencies                        ##
+################################################################################
+
+### ScaleIO
+  - package: github.com/emccode/goscaleio
+    ref:     support/tls-sio-gw-2.0.0.2


### PR DESCRIPTION
This patch introduces two new environment variables for controlling Docker builds:

Environment Variable | Description
----------------------|------------
`DLOCAL_IMPORTS` |  Specify a list of space-delimited import paths that will be copied from the host OS's `GOPATH` into the container build's vendor area, overriding the dependency code that would normally be fetched by Glide.<br/><br/>For example, the project's `glide.yaml` file might specify to build REX-Ray with libStorage v0.2.1. However, the following command will build REX-Ray using the libStorage sources on the host OS at `$GOPATH/src/github.com/emccode/libstorage`:<br/><br/><pre lang="bash">$ DLOCAL_IMPORTS=github.com/emccode/libstorage make docker-build</pre>Using local sources can sometimes present a problem due to missing dependencies. Please see the next environment variable for instructions on how to overcome this issue.
`DGLIDE_YAML` | Specify a file that will be used for the container build in place of the standard `glide.yaml` file.<br/><br/>This is necessary for occasions when sources injected into the build via the `DLOCAL_IMPORTS` variable import packages that are not imported by the package specified in the project's standard `glide.yaml` file.<br/><br/>For example, if `glide.yaml` specifies that REX-Ray depends upon libStorage v0.2.1, but `DLOCAL_IMPORTS` specifies the value `github.com/emccode/libstorage` and the libStorage source code on the host includes a new storage driver not present in the v0.2.1 version, Glide will not fetch the new driver's dependencies when doing the container build.<br/><br/>So it may be necessary to use `DGLIDE_YAML` to provide a superset of the project's standard `glide.yaml` file which also includes the dependencies necessary to build the packages specified in `DLOCAL_IMPORTS`.