### PR TITLE
Docker-Test DGOOS Fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ ifeq (1,$(DBUILD_ONCE))
 	docker stop $(DNAME) &> /dev/null && docker rm $(DNAME) &> /dev/null
 endif
 
+docker-test: DGOOS=linux
 docker-test: docker-init
 	docker exec -t $(DNAME) make -C $(DPATH) test
 


### PR DESCRIPTION
This patch updates the "docker-test" target by explicitly setting its
environment variable DGOOS to "linux" so that it is used in the
"docker-init" target as well, despite the value of the host OS. This is
so the initial build is not for an OS other than the one required to run
the tests inside the container, which will only run for linux (the
container's OS).