### PR TITLE
New CLI Revisions

### DIFF
--- a/cli/cli/cli.go
+++ b/cli/cli/cli.go
@@ -87,6 +87,7 @@ type CLI struct {
 	devuceUnmountCmd *cobra.Command
 	deviceFormatCmd  *cobra.Command
 
+	dryRun                  bool
 	outputFormat            string
 	outputTemplate          string
 	outputTemplateTabs      bool
@@ -281,6 +282,11 @@ func (c *CLI) addOutputFormatFlag(fs *pflag.FlagSet) {
 	fs.BoolVarP(
 		&c.outputTemplateTabs, "templateTabs", "", true,
 		"Set to true to use a Go tab writer with the output template")
+}
+
+func (c *CLI) addDryRunFlag(fs *pflag.FlagSet) {
+	fs.BoolVarP(&c.dryRun, "dryRun", "n", false,
+		"Show what action(s) will occur, but do not execute them.")
 }
 
 func (c *CLI) updateLogLevel() {


### PR DESCRIPTION
This patch updates the volume CLI commands so that any command that performs an action (all volume commands other than `ls` or `path`) will only perform the action when there are multiple results **IFF** a regular expression was used to generate those results. If a provided string matched more than one prefix of a volume's ID or name then the result set is considered non-unique and will not be processed.

Additionally, a new flag `-n|--dryRun` has been introduced that will cause several of the action-oriented volume commands to list the volumes that will be acted upon, but not actually act upon them.